### PR TITLE
[13.0][FIX] hr_attendance_autoclose: Fix error in hr.leave form (user without employee group)

### DIFF
--- a/hr_attendance_autoclose/models/__init__.py
+++ b/hr_attendance_autoclose/models/__init__.py
@@ -1,3 +1,4 @@
 from . import hr_attendance
 from . import hr_employee
+from . import hr_employee_public
 from . import res_company

--- a/hr_attendance_autoclose/models/hr_employee_public.py
+++ b/hr_attendance_autoclose/models/hr_employee_public.py
@@ -1,0 +1,11 @@
+# Copyright 2020 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+
+    _inherit = "hr.employee.public"
+
+    no_autoclose = fields.Boolean(string="Don't Autoclose Attendances")

--- a/hr_attendance_autoclose/readme/CONTRIBUTORS.rst
+++ b/hr_attendance_autoclose/readme/CONTRIBUTORS.rst
@@ -1,2 +1,6 @@
 * Aaron Henriquez <ahforgeflow@forgeflow.com>
 * Kitti U. <kittiu@ecosoft.co.th>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+    * Víctor Martínez


### PR DESCRIPTION
Actually error appear in `hr.leave` form when user without employee group. 
The solution is create `no_autoclose` field in `hr.employee.public` model because is the model that users without employee groups can access.

@Tecnativa TT27054