### PR TITLE
[13.0][FIX] hr_attendance_report_theoretical_time: Fix error in hr.leave form (user without employee group)

### DIFF
--- a/hr_attendance_report_theoretical_time/models/__init__.py
+++ b/hr_attendance_report_theoretical_time/models/__init__.py
@@ -2,6 +2,7 @@
 
 from . import hr_attendance
 from . import hr_employee
+from . import hr_employee_public
 from . import hr_holidays_public
 from . import hr_leave
 from . import hr_leave_type

--- a/hr_attendance_report_theoretical_time/models/hr_employee_public.py
+++ b/hr_attendance_report_theoretical_time/models/hr_employee_public.py
@@ -1,0 +1,15 @@
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+    _inherit = "hr.employee.public"
+
+    theoretical_hours_start_date = fields.Date(
+        help="Fill this field for setting a manual start date for computing "
+        "the theoretical hours independently from the attendances. If "
+        "not filled, employee creation date or the calendar start date "
+        "will be used (the greatest of both)."
+    )


### PR DESCRIPTION
Actually error appear in `hr.leave` form when user without employee group. 
The solution is create `theoretical_hours_start_date` field in `hr.employee.public` model because is the model that users without employee groups can access.

Please, @pedrobaeza and @joao-p-marques review it

@Tecnativa TT27054