### PR TITLE
[13.0][FIX] hr_attendance_report_theoretical_time: Remove search_default_my (context) when hr_attendance_theoretical_action is load from wizard

### DIFF
--- a/hr_attendance_report_theoretical_time/readme/CONTRIBUTORS.rst
+++ b/hr_attendance_report_theoretical_time/readme/CONTRIBUTORS.rst
@@ -2,4 +2,5 @@
 
   * Pedro M. Baeza.
   * David Vidal
+  * Víctor Martínez
 * Pedro Gonzalez <pedro.gonzalez@pesol.es>

--- a/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Creu Blanca
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -49,4 +50,7 @@ class WizardTheoreticalTime(models.TransientModel):
             "hr_attendance_report_theoretical_time." "hr_attendance_theoretical_action"
         ).read()[0]
         action["domain"] = [("employee_id", "in", self.employee_ids.ids)]
+        action[
+            "context"
+        ] = "{'search_default_previous_month': 1, 'search_default_current_month': 1}"
         return action


### PR DESCRIPTION
Remove search_default_my (context) when hr_attendance_theoretical_action is load from wizard

Related to 12.0: https://github.com/OCA/hr/pull/960

![wizard-error-context](https://user-images.githubusercontent.com/4117568/105706621-0dc50d80-5f12-11eb-834c-6400fe8e2030.gif)

@Tecnativa TT27900