### PR TITLE
[13.0][IMP] hr_attendance_report_theoretical_time: Add department_id in report

### DIFF
--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
@@ -1,4 +1,5 @@
 # Copyright 2017-2019 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from datetime import datetime, time
@@ -19,6 +20,9 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
     employee_id = fields.Many2one(
         comodel_name="hr.employee", string="Employee", readonly=True
     )
+    department_id = fields.Many2one(
+        comodel_name="hr.department", string="Department", readonly=True,
+    )
     date = fields.Date(string="Date", readonly=True)
     worked_hours = fields.Float(string="Worked", readonly=True)
     theoretical_hours = fields.Float(string="Theoric", readonly=True)
@@ -31,6 +35,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
         return """
             min(id) AS id,
             employee_id,
+            department_id,
             date,
             sum(worked_hours) AS worked_hours,
             max(theoretical_hours) AS theoretical_hours,
@@ -46,6 +51,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
                 ('x'||substr(MD5('HA' || ha.id::text), 1, 8))::bit(32)::int
             ) AS id,
             ha.employee_id AS employee_id,
+            he.department_id AS department_id,
             ha.check_in::date AS date,
             ha.worked_hours AS worked_hours,
             ha.theoretical_hours AS theoretical_hours,
@@ -55,6 +61,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
     def _from_sub1(self):
         return """
             hr_attendance ha
+            LEFT JOIN hr_employee AS he ON ha.employee_id = he.id
             """
 
     def _where_sub1(self):
@@ -69,6 +76,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
                 ), 1, 8))::bit(32)::int
             ) AS id,
             he.id AS employee_id,
+            he.department_id AS department_id,
             gs::date AS date,
             0 AS worked_hours,
             -1 AS theoretical_hours,
@@ -124,6 +132,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
     def _group_by(self):
         return """
             employee_id,
+            department_id,
             date
             """
 

--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
@@ -41,6 +41,7 @@
         <field name="arch" type="xml">
             <pivot disable_linking="1">
                 <field name="employee_id" type="row" />
+                <field name="department_id" />
                 <field name="date" type="col" />
                 <field name="worked_hours" type="measure" widget="float_time" />
                 <field name="theoretical_hours" type="measure" widget="float_time" />
@@ -53,6 +54,7 @@
         <field name="arch" type="xml">
             <graph>
                 <field name="employee_id" />
+                <field name="department_id" />
                 <field name="date" />
                 <field name="theoretical_hours" type="measure" />
             </graph>


### PR DESCRIPTION
Add `department_id` field in report
![example](https://user-images.githubusercontent.com/4117568/105714444-a3659a80-5f1c-11eb-98cb-10697091a7fc.png)

Related to 12.0: https://github.com/OCA/hr/pull/961

@Tecnativa TT27900