### PR TITLE
[13.0][FIX] hr_attendance_autoclose: Show no_autoclose field in view correctly

### DIFF
--- a/hr_attendance_autoclose/views/hr_employee.xml
+++ b/hr_attendance_autoclose/views/hr_employee.xml
@@ -10,9 +10,9 @@
             ref="hr_attendance.view_employee_form_inherit_hr_attendance"
         />
         <field name="arch" type="xml">
-            <field name="barcode" position="after">
+            <xpath expr="//group[@name='identification_group']" position="inside">
                 <field name="no_autoclose" />
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Show `no_autoclose` field in view correctly

![employee](https://user-images.githubusercontent.com/4117568/106445369-3b183b00-647f-11eb-822b-85c34368e385.png)

Please @joao-p-marques can you review it?

@Tecnativa TT28087