### PR TITLE
[14.0][FIX] hr_attendance_report_theoretical_time: Set default department_id in wizard correctly according to companies + Filter by all employees (including archived) in wizard

### DIFF
--- a/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
@@ -54,7 +54,9 @@ class WizardTheoreticalTime(models.TransientModel):
         action = self.env.ref(
             "hr_attendance_report_theoretical_time." "hr_attendance_theoretical_action"
         ).read()[0]
-        action["domain"] = [("employee_id", "in", self.employee_ids.ids)]
+        action["domain"] = [
+            ("employee_id", "in", self.with_context(active_test=False).employee_ids.ids)
+        ]
         action[
             "context"
         ] = "{'search_default_previous_month': 1, 'search_default_current_month': 1}"

--- a/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
@@ -10,16 +10,21 @@ class WizardTheoreticalTime(models.TransientModel):
     _name = "wizard.theoretical.time"
     _description = "Filtered Theoretical Time"
 
-    employee_ids = fields.Many2many("hr.employee", string="Employees")
+    employee_ids = fields.Many2many(comodel_name="hr.employee", string="Employees")
 
-    department_id = fields.Many2one("hr.department", string="Department")
-    category_ids = fields.Many2many("hr.employee.category", string="Tag")
+    department_id = fields.Many2one(comodel_name="hr.department", string="Department")
+    category_ids = fields.Many2many(comodel_name="hr.employee.category", string="Tag")
 
     @api.model
     def default_get(self, fields):
         res = super().default_get(fields)
         if self.env.user.employee_ids:
-            res["department_id"] = self.env.user.employee_ids[0].department_id.id
+            department = self.env["hr.department"].search(
+                [("id", "in", self.env.user.employee_ids.mapped("department_id").ids)],
+                limit=1,
+            )
+            if department:
+                res["department_id"] = department.id
         return res
 
     def _prepare_employee_domain(self):


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/hr-attendance/pull/42

Some changes:
- Set default `department_id` in wizard correctly according to companies.
- Filter by all employees (including archived employees) in wizard

Steps to reproduce:
- Company A > Employee A > Department A (Company A)
- Company B > Employee B > Department B (Company B)
- Company C

- [Company A] Attendances > Reporting > Select employees > Department A is set.
- [Company B] Attendances > Reporting > Select employees > Department B is set.
- [Company C] Attendances > Reporting > Select employees > Department is empty.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT31451