### PR TITLE
[14.0] fix #40 hr attendance autoclose

### DIFF
--- a/hr_attendance_autoclose/models/hr_employee.py
+++ b/hr_attendance_autoclose/models/hr_employee.py
@@ -8,4 +8,6 @@ class HrEmployee(models.Model):
 
     _inherit = "hr.employee"
 
-    no_autoclose = fields.Boolean(string="Don't Autoclose Attendances")
+    no_autoclose = fields.Boolean(
+        string="Don't Autoclose Attendances", groups="hr.group_hr_user"
+    )

--- a/hr_attendance_autoclose/tests/test_hr_attendance_auto_close.py
+++ b/hr_attendance_autoclose/tests/test_hr_attendance_auto_close.py
@@ -50,3 +50,27 @@ class TestHrAttendanceReason(TransactionCase):
         )
         self.hr_attendance.check_for_incomplete_attendances()
         self.assertFalse(att2.attendance_reason_ids)
+
+    def test_hr_employee_can_still_read_employee_and_hr_public_employee(self):
+        """This test ensure the following comment from hr.employee model has been take
+        in consideration::
+
+            NB: Any field only available on the model hr.employee (i.e. not on the
+            hr.employee.public model) should have `groups="hr.group_hr_user"` on its
+            definition to avoid being prefetched when the user hasn't access to the
+            hr.employee model. Indeed, the prefetch loads the data for all the fields
+            that are available according to the group defined on them.
+        """
+        test_user = self.env["res.users"].create(
+            {
+                "name": "test",
+                "login": "test",
+                "groups_id": [
+                    (6, 0, [self.env.ref("base.group_user").id]),
+                ],
+            }
+        )
+
+        employees = self.env["hr.employee"].with_user(test_user).search([])
+        for empl in employees:
+            self.assertTrue(empl.name)


### PR DESCRIPTION
follow hr.employee instruction any fields on that model must be limited to hr.group_hr_user
to avoid prefetch error while browsing fields