### PR TITLE
[FIX] hr_attendance_modification_tracking

### DIFF
--- a/hr_attendance_modification_tracking/models/hr_attendance.py
+++ b/hr_attendance_modification_tracking/models/hr_attendance.py
@@ -16,9 +16,7 @@ class HrAttendance(models.Model):
     check_out = fields.Datetime(tracking=True)
     time_changed_manually = fields.Boolean(
         string="Time changed",
-        compute="_compute_time_changed_manually",
         default=False,
-        store=True,
         help="This attendance has been manually changed by user. If attendance"
         " is created from form view, a 60 seconds tolerance will "
         "be applied.",


### PR DESCRIPTION
The compute method was removed in migration to 14, but the field definition still referenced the compute method