### PR TITLE
[FIX] hr_attendance_report_theoretical_time: access right to pivot report

### DIFF
--- a/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/wizards/wizard_theoretical_time.py
@@ -51,9 +51,9 @@ class WizardTheoreticalTime(models.TransientModel):
 
     def view_report(self):
         self.ensure_one()
-        action = self.env.ref(
-            "hr_attendance_report_theoretical_time." "hr_attendance_theoretical_action"
-        ).read()[0]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "hr_attendance_report_theoretical_time.hr_attendance_theoretical_action"
+        )
         action["domain"] = [
             ("employee_id", "in", self.with_context(active_test=False).employee_ids.ids)
         ]


### PR DESCRIPTION
When clicking on the Reporting => Select Employees => View Report stat button of a wizard, a user (that actually has proper rights) might not have enough access right to read the window action.
![access-error](https://user-images.githubusercontent.com/29202630/147135277-ee6b9ddf-e411-4528-afaf-62d1b33a5636.png)
Use _for_xml_id for safe openning.
