### PR TITLE
[13.0][IMP] hr_attendance_report_theoretical_time: Separate the setup() of the tests in TestHrAttendanceReportTheoreticalTimeBase to improve the inheritance of tests in other modules.

### DIFF
--- a/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
@@ -4,7 +4,7 @@
 from odoo.tests import common
 
 
-class TestHrAttendanceReportTheoreticalTime(common.SavepointCase):
+class TestHrAttendanceReportTheoreticalTimeBase(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -136,6 +136,8 @@ class TestHrAttendanceReportTheoreticalTime(common.SavepointCase):
                     )
                 )
 
+
+class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTimeBase):
     def test_theoretical_hours(self):
         # EMPLOYEE 1
         # 1946-12-23


### PR DESCRIPTION
Separate the `setup()` of the tests in `TestHrAttendanceReportTheoreticalTimeBase` to improve the inheritance of tests in other modules.

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT34898