### PR TITLE
hr_attendance_autoclose: remove almost duplicated field worked_hours from tree

### DIFF
--- a/hr_attendance_autoclose/views/hr_attendance_view.xml
+++ b/hr_attendance_autoclose/views/hr_attendance_view.xml
@@ -12,13 +12,16 @@
         </field>
     </record>
     <record id="view_attendance_tree" model="ir.ui.view">
-        <field name="name">hr.attendance.form</field>
+        <field name="name">hr.attendance.tree</field>
         <field name="model">hr.attendance</field>
         <field name="inherit_id" ref="hr_attendance.view_attendance_tree" />
         <field name="priority">400</field>
         <field name="arch" type="xml">
             <field name="check_out" position="after">
                 <field name="open_worked_hours" widget="float_time" />
+            </field>
+            <field name="worked_hours" position="attributes">
+                <attribute name="invisible">1</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Field open_worked_hours can simply replace worked_hours entirely. It shows the same info when an attendance is closed, and more info when it's still open. No reason to have both fields in the tree view