### PR TITLE
[15.0][FIX] hr_attendance_report_theoretical_time: tests

### DIFF
--- a/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
@@ -98,8 +98,6 @@ class TestHrAttendanceReportTheoreticalTimeBase(common.TransactionCase):
                 "requires_allocation": "no",
             }
         )
-        # Remove timezone for controlling data better
-        cls.env.user.tz = False
         # Force employee create_date for having auto-generated report entries
         cls.env.cr.execute(
             "UPDATE hr_employee SET create_date = %s " "WHERE id in %s",


### PR DESCRIPTION
Tests rely on removing tz from the current user and it isn't possible anymore after https://github.com/odoo/odoo/commit/d6f2437e9ce69a585c33940c6a2c18f4a6c7fdad#diff-38469def2f870bb866f971f57797dd7c21b6a95d52a8eae72f832f0eea2434f9R105

