### PR TITLE
[14.0][FIX] hr_attendance_modification_tracking: squash tracking warning

### DIFF
--- a/hr_attendance_modification_tracking/models/hr_employee.py
+++ b/hr_attendance_modification_tracking/models/hr_employee.py
@@ -9,3 +9,6 @@ class HrEmployeeBase(models.AbstractModel):
 
     last_check_in = fields.Datetime(tracking=False)
     last_check_out = fields.Datetime(tracking=False)
+
+    def _valid_field_parameter(self, field, name):
+        return name == "tracking" or super()._valid_field_parameter(field, name)


### PR DESCRIPTION
Removes the warning in the logs about "tracking" not being allowed on `hr.employee.public`

```
odoo.fields: Field hr.employee.public.last_check_in: unknown parameter 'tracking', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
odoo.fields: Field hr.employee.public.last_check_out: unknown parameter 'tracking', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
```

Ref #110 