### PR TITLE
[16.0] Add module hr_attendance_calendar_view

### DIFF
--- a/hr_attendance_calendar_view/__manifest__.py
+++ b/hr_attendance_calendar_view/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2023 JumpTo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Add calendar view to attendance, hr_attendance_calendar_view",
+    "summary": """
+        This module adds the calendar view as an option to display attendance""",
+    "license": "AGPL-3",
+    "author": "Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/hr-attendance",
+    "category": "Human Resources",
+    "version": "16.0.1.0.0",
+    "depends": ["base", "hr_attendance"],
+    "data": [
+        "views/hr_attendance_calendar_views.xml",
+    ],
+}

--- a/hr_attendance_calendar_view/views/hr_attendance_calendar_views.xml
+++ b/hr_attendance_calendar_view/views/hr_attendance_calendar_views.xml
@@ -1,0 +1,21 @@
+<odoo>
+    <record id="hr_attendance.hr_attendance_action" model="ir.actions.act_window">
+        <field name="view_mode">tree,kanban,calendar,form</field>
+    </record>
+    <record id="view_attendance_calendar" model="ir.ui.view">
+        <field name="name">hr.attendance.calendar</field>
+        <field name="model">hr.attendance</field>
+        <field name="arch" type="xml">
+            <!-- enable quick_add will result of an error as model hr.attendance doesnt have editable name field  -->
+            <calendar
+                string="Employee attendances"
+                date_start="check_in"
+                date_stop="check_out"
+                color="employee_id"
+                quick_add="false"
+            >
+                <field name="employee_id" />
+            </calendar>
+        </field>
+    </record>
+</odoo>

--- a/setup/hr_attendance_calendar_view/odoo/addons/hr_attendance_calendar_view
+++ b/setup/hr_attendance_calendar_view/odoo/addons/hr_attendance_calendar_view
@@ -1,0 +1,1 @@
+../../../../hr_attendance_calendar_view

--- a/setup/hr_attendance_calendar_view/setup.py
+++ b/setup/hr_attendance_calendar_view/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Previously added in 15.0
https://github.com/OCA/hr-attendance/pull/122

It's the same module, yet in 16 there can be some tricky interaction where new attendance may not be saved automatically.