### PR TITLE
[FIX] handle Validation error

### DIFF
--- a/hr_attendance_rfid/models/hr_employee.py
+++ b/hr_attendance_rfid/models/hr_employee.py
@@ -69,6 +69,6 @@ class HrEmployeeBase(models.AbstractModel):
                 res["error_message"] = msg
                 return res
         except Exception as e:
-            res["error_message"] = e
-            _logger.error(e)
+            res["error_message"] = str(e)
+            _logger.error(str(e))
         return res


### PR DESCRIPTION
If a ValidationError arises during the processing of an attendance, you must use str(e) in order to get the error message. Using only e gives later problems on other modules that can not handle with Objects of type ValidationError