### PR TITLE
[15.0][FIX] hr_attendance_report_theoretical_time: Show the Reports menu to a basic user

### DIFF
--- a/hr_attendance_report_theoretical_time/i18n/es.po
+++ b/hr_attendance_report_theoretical_time/i18n/es.po
@@ -6,26 +6,31 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-14 13:18+0000\n"
-"PO-Revision-Date: 2021-01-25 15:44+0000\n"
+"POT-Creation-Date: 2023-08-31 06:15+0000\n"
+"PO-Revision-Date: 2023-08-31 08:16+0200\n"
 "Last-Translator: Víctor Martínez <victor.martinez@tecnativa.com>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: hr_attendance_report_theoretical_time
 #: model:ir.ui.menu,name:hr_attendance_report_theoretical_time.menu_hr_attendance_theoretical_report
-msgid "All Employees"
-msgstr "Todos los empleados"
+msgid "Analysis"
+msgstr "Análisis"
 
 #. module: hr_attendance_report_theoretical_time
 #: model:ir.model,name:hr_attendance_report_theoretical_time.model_hr_attendance
 msgid "Attendance"
 msgstr "Asistencias"
+
+#. module: hr_attendance_report_theoretical_time
+#: model:ir.model,name:hr_attendance_report_theoretical_time.model_hr_attendance_report
+msgid "Attendance Statistics"
+msgstr "Análisis de asistencias"
 
 #. module: hr_attendance_report_theoretical_time
 #: model:ir.ui.menu,name:hr_attendance_report_theoretical_time.menu_hr_attendance_report
@@ -250,6 +255,7 @@ msgstr "Etiqueta"
 
 #. module: hr_attendance_report_theoretical_time
 #: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_hr_attendance__theoretical_hours
+#: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_hr_attendance_report__theoretical_hours
 msgid "Theoretical Hours"
 msgstr "Horas teóricas"
 
@@ -282,7 +288,7 @@ msgstr "Tiempo libre"
 #. module: hr_attendance_report_theoretical_time
 #: model:ir.model,name:hr_attendance_report_theoretical_time.model_hr_leave_type
 msgid "Time Off Type"
-msgstr ""
+msgstr "Tipo de tiempo libre"
 
 #. module: hr_attendance_report_theoretical_time
 #: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_recompute_theoretical_attendance__date_to

--- a/hr_attendance_report_theoretical_time/i18n/hr_attendance_report_theoretical_time.pot
+++ b/hr_attendance_report_theoretical_time/i18n/hr_attendance_report_theoretical_time.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-08-31 06:15+0000\n"
+"PO-Revision-Date: 2023-08-31 06:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15,7 +17,7 @@ msgstr ""
 
 #. module: hr_attendance_report_theoretical_time
 #: model:ir.ui.menu,name:hr_attendance_report_theoretical_time.menu_hr_attendance_theoretical_report
-msgid "All Employees"
+msgid "Analysis"
 msgstr ""
 
 #. module: hr_attendance_report_theoretical_time

--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
@@ -73,6 +73,10 @@
             name="groups_id"
             eval="[(4, ref('hr_attendance.group_hr_attendance'))]"
         />
+        <!-- We need to leave the action empty for consistency because we are going
+            to set different submenus, otherwise the Reports menu would not be
+            displayed to a basic user. !-->
+        <field name="action" eval="False" />
     </record>
     <menuitem
         id="menu_hr_attendance_report"
@@ -91,7 +95,7 @@
     />
     <menuitem
         id="menu_hr_attendance_theoretical_report"
-        name="All Employees"
+        name="Analysis"
         action="hr_attendance_theoretical_action"
         parent="menu_hr_attendance_theoretical_root"
         groups="hr_attendance.group_hr_attendance"


### PR DESCRIPTION
Show the Reports menu to a basic user (without Attendance > Officer group)

We need to leave the action empty for consistency because we are going to set different submenus, otherwise the Reports menu would not be displayed to a basic user.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT44849