### PR TITLE
[FIX][14.0] hr_attendance_rfid - Use a with savepoint instead of catching the error allowing a rollback

### DIFF
--- a/hr_attendance_rfid/i18n/fr.po
+++ b/hr_attendance_rfid/i18n/fr.po
@@ -4,17 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0\n"
+"Project-Id-Version: Odoo Server 14.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2019-05-23 20:19+0000\n"
-"Last-Translator: Kévin Allard <kallard@efficom-lille.com>\n"
-"Language-Team: none\n"
-"Language: fr\n"
+"POT-Creation-Date: 2023-10-19 13:43+0000\n"
+"PO-Revision-Date: 2023-10-19 13:43+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 3.6.1\n"
+"Plural-Forms: \n"
 
 #. module: hr_attendance_rfid
 #: code:addons/hr_attendance_rfid/models/hr_employee.py:0
@@ -25,12 +24,12 @@ msgstr "Présence enregistrée pour l'employé(e) %s"
 #. module: hr_attendance_rfid
 #: model:ir.model,name:hr_attendance_rfid.model_hr_employee_base
 msgid "Basic Employee"
-msgstr ""
+msgstr "Employés"
 
 #. module: hr_attendance_rfid
 #: model:ir.model.fields,field_description:hr_attendance_rfid.field_hr_employee_base__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Libellé"
 
 #. module: hr_attendance_rfid
 #: model:ir.model.fields,field_description:hr_attendance_rfid.field_hr_employee_base__id
@@ -40,7 +39,7 @@ msgstr ""
 #. module: hr_attendance_rfid
 #: model:ir.model.fields,field_description:hr_attendance_rfid.field_hr_employee_base____last_update
 msgid "Last Modified on"
-msgstr ""
+msgstr "Dernière modification le"
 
 #. module: hr_attendance_rfid
 #: code:addons/hr_attendance_rfid/models/hr_employee.py:0
@@ -72,6 +71,3 @@ msgstr "Code de carte RFID"
 #: model:ir.model.constraint,message:hr_attendance_rfid.constraint_hr_employee_rfid_card_code_uniq
 msgid "The rfid code should be unique."
 msgstr "Le code rfid doit être unique."
-
-#~ msgid "Employee"
-#~ msgstr "Employé(e)"

--- a/hr_attendance_rfid/i18n/hr_attendance_rfid.pot
+++ b/hr_attendance_rfid/i18n/hr_attendance_rfid.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 14.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-19 11:31+0000\n"
+"PO-Revision-Date: 2023-10-19 11:31+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"

--- a/hr_attendance_rfid/models/hr_employee.py
+++ b/hr_attendance_rfid/models/hr_employee.py
@@ -53,21 +53,24 @@ class HrEmployeeBase(models.AbstractModel):
             res["error_message"] = msg
             return res
         try:
-            attendance = employee._attendance_action_change()
-            if attendance:
-                msg = _("Attendance recorded for employee %s") % employee.name
-                _logger.debug(msg)
-                res["logged"] = True
-                if attendance.check_out:
-                    res["action"] = "check_out"
+            with self.env.cr.savepoint():
+                attendance = employee._attendance_action_change()
+                if attendance:
+                    msg = _("Attendance recorded for employee %s") % employee.name
+                    _logger.info(msg)
+                    res["logged"] = True
+                    if attendance.check_out:
+                        res["action"] = "check_out"
+                    else:
+                        res["action"] = "check_in"
+                    return res
                 else:
-                    res["action"] = "check_in"
-                return res
-            else:
-                msg = _("No attendance was recorded for employee %s") % employee.name
-                _logger.error(msg)
-                res["error_message"] = msg
-                return res
+                    msg = (
+                        _("No attendance was recorded for employee %s") % employee.name
+                    )
+                    _logger.error(msg)
+                    res["error_message"] = msg
+                    return res
         except Exception as e:
             res["error_message"] = str(e)
             _logger.error(str(e))


### PR DESCRIPTION
If an Error arises during the processing of an attendance, as it is not raised and just logged there is no rollback after. This is why I use a with self.env.cr.savepoint statement, to force a rollback in case of error trigger.