### PR TITLE
[FIX] hr_attendance_reason: search_read params

### DIFF
--- a/hr_attendance_reason/models/hr_employee_base.py
+++ b/hr_attendance_reason/models/hr_employee_base.py
@@ -15,9 +15,16 @@ class HrEmployeeBase(models.AbstractModel):
     )
 
     @api.model
-    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
+    def search_read(
+        self, domain=None, fields=None, offset=0, limit=None, order=None, **read_kwargs
+    ):
         fields = fields or []
         fields += self.env.context.get("extra_fields", [])
         return super().search_read(
-            domain=domain, fields=fields, offset=offset, limit=limit, order=order
+            domain=domain,
+            fields=fields,
+            offset=offset,
+            limit=limit,
+            order=order,
+            **read_kwargs
         )


### PR DESCRIPTION
`search_read` doesn't match definition from core, `read_kwargs` was missing.

This can be tested in a database this module and `pos_hr` installed, and trying to login in a POS.