### PR TITLE
raise AccessError if no employee is found for current user

### DIFF
--- a/hr_attendance_overtime/models/hr_employee.py
+++ b/hr_attendance_overtime/models/hr_employee.py
@@ -5,7 +5,8 @@ from datetime import datetime, time
 from dateutil.relativedelta import relativedelta
 from pytz import timezone, utc
 
-from odoo import SUPERUSER_ID, api, fields, models
+from odoo import SUPERUSER_ID, _, api, fields, models
+from odoo.exceptions import UserError
 from odoo.osv import expression
 
 
@@ -17,6 +18,8 @@ class HrEmployeeBase(models.AbstractModel):
         """Method used by my attendance/kiosk view in order
         to display employee planning and working times"""
         employee = self.search(empl_domain)
+        if not employee:
+            raise UserError(_("Employee not found or not created for current user"))
         employee.ensure_one()
         now = fields.Datetime.now()
         tz = timezone(employee.tz)

--- a/hr_attendance_overtime/tests/test_attendance_overtime.py
+++ b/hr_attendance_overtime/tests/test_attendance_overtime.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from freezegun import freeze_time
 from psycopg2 import IntegrityError
 
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger
 
@@ -609,6 +610,18 @@ class TestHrAttendanceOverTimeEuropeParis(TransactionCase):
             self.assertEqual(attendance.check_out, datetime(2021, 12, 13, 9, 1))
             self.assertFalse(attendance.is_overtime)
             self.assertFalse(attendance.attendance_reason_ids)
+
+    def test_todays_working_times_user_without_employee(self):
+        user = self.env["res.users"].create(
+            {
+                "name": "Test User",
+                "login": "test_user",
+                "email": "test2@user.com",
+                "tz": "UTC",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.employee.todays_working_times([("id", "=", user.id)])
 
     def test_todays_working_times(self):
         self.maxDiff = None


### PR DESCRIPTION
AccessError to be raised if no employee is found matching the domain, providing a clear error message and avoiding `ValueError: Expected singleton: hr.employee()`