### PR TITLE
[FIX] [16.0] hr_contract_update_overtime: Reorganize Leaves across Contracts + Message

### DIFF
--- a/hr_contract_update_overtime/README.rst
+++ b/hr_contract_update_overtime/README.rst
@@ -38,6 +38,9 @@ You can Update Overtime in different ways:
 -  Header button on Contract History form view
 -  Header button on Contract form view
 
+If you Update Overtime from Contract History, leaves will also be
+reorganized across their contract calendars.
+
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
    Only for development or testing purpose, do not use in production.

--- a/hr_contract_update_overtime/i18n/es.po
+++ b/hr_contract_update_overtime/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-17 06:10+0000\n"
-"PO-Revision-Date: 2024-07-17 08:10+0200\n"
+"POT-Creation-Date: 2024-07-17 09:15+0000\n"
+"PO-Revision-Date: 2024-07-17 11:16+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -33,6 +33,17 @@ msgstr "Histórico de contratación"
 #, python-format
 msgid "Overtime updated"
 msgstr "Horas Extra actualizadas"
+
+#. module: hr_contract_update_overtime
+#: model_terms:ir.ui.view,arch_db:hr_contract_update_overtime.hr_contract_history_view_form
+msgid ""
+"This action will also reorganize all the Employee's leaves by distributing "
+"them across their contract calendars. If you do not want this to happen, "
+"you can Update Overtime from a specific contract."
+msgstr ""
+"Esta acción también reorganizará todas las ausencias del Empleado "
+"distribuyéndolas en los calendarios de sus contratos. Si no quieres que "
+"esto pase, puedes actualizar las Horas Extra desde un contrato específico."
 
 #. module: hr_contract_update_overtime
 #: model:ir.actions.server,name:hr_contract_update_overtime.hr_contract_history_update_overtime_all_action

--- a/hr_contract_update_overtime/i18n/es.po
+++ b/hr_contract_update_overtime/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-11 08:46+0000\n"
-"PO-Revision-Date: 2024-07-11 10:47+0200\n"
+"POT-Creation-Date: 2024-07-17 06:10+0000\n"
+"PO-Revision-Date: 2024-07-17 08:10+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -26,6 +26,13 @@ msgstr "Contrato"
 #: model:ir.model,name:hr_contract_update_overtime.model_hr_contract_history
 msgid "Contract history"
 msgstr "Histórico de contratación"
+
+#. module: hr_contract_update_overtime
+#. odoo-python
+#: code:addons/hr_contract_update_overtime/models/hr_contract.py:0
+#, python-format
+msgid "Overtime updated"
+msgstr "Horas Extra actualizadas"
 
 #. module: hr_contract_update_overtime
 #: model:ir.actions.server,name:hr_contract_update_overtime.hr_contract_history_update_overtime_all_action

--- a/hr_contract_update_overtime/i18n/hr_contract_update_overtime.pot
+++ b/hr_contract_update_overtime/i18n/hr_contract_update_overtime.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-17 06:10+0000\n"
-"PO-Revision-Date: 2024-07-17 06:10+0000\n"
+"POT-Creation-Date: 2024-07-17 09:15+0000\n"
+"PO-Revision-Date: 2024-07-17 09:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -30,6 +30,14 @@ msgstr ""
 #: code:addons/hr_contract_update_overtime/models/hr_contract.py:0
 #, python-format
 msgid "Overtime updated"
+msgstr ""
+
+#. module: hr_contract_update_overtime
+#: model_terms:ir.ui.view,arch_db:hr_contract_update_overtime.hr_contract_history_view_form
+msgid ""
+"This action will also reorganize all the Employee's leaves by distributing "
+"them across their contract calendars. If you do not want this to happen, you"
+" can Update Overtime from a specific contract."
 msgstr ""
 
 #. module: hr_contract_update_overtime

--- a/hr_contract_update_overtime/i18n/hr_contract_update_overtime.pot
+++ b/hr_contract_update_overtime/i18n/hr_contract_update_overtime.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-17 06:10+0000\n"
+"PO-Revision-Date: 2024-07-17 06:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,6 +23,13 @@ msgstr ""
 #. module: hr_contract_update_overtime
 #: model:ir.model,name:hr_contract_update_overtime.model_hr_contract_history
 msgid "Contract history"
+msgstr ""
+
+#. module: hr_contract_update_overtime
+#. odoo-python
+#: code:addons/hr_contract_update_overtime/models/hr_contract.py:0
+#, python-format
+msgid "Overtime updated"
 msgstr ""
 
 #. module: hr_contract_update_overtime

--- a/hr_contract_update_overtime/models/hr_contract.py
+++ b/hr_contract_update_overtime/models/hr_contract.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
 from datetime import datetime, timedelta
 
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class HrContract(models.Model):
@@ -25,3 +25,9 @@ class HrContract(models.Model):
                 continue
             attendances = record._get_attendances()
             attendances._update_overtime()
+            record.message_post(
+                body=_("Overtime updated"),
+                subtype_xmlid="mail.mt_note",
+                message_type="comment",
+                author_id=self.env.user.partner_id.id,
+            )

--- a/hr_contract_update_overtime/models/hr_contract_history.py
+++ b/hr_contract_update_overtime/models/hr_contract_history.py
@@ -8,19 +8,17 @@ class HrContractHistory(models.Model):
 
     def action_update_overtime(self):
         for record in self:
-            all_contracts = record.mapped("contract_ids").sorted(
-                "date_start", reverse=False
-            )
+            all_contracts = record.contract_ids.sorted("date_start", reverse=False)
             valid_contracts = all_contracts.filtered(
                 lambda c: c.state in {"open", "close"}
             )
             for contract in valid_contracts:
                 other_contracts = all_contracts - contract
                 # Reorganize Leaves
-                other_contracts.mapped("resource_calendar_id").transfer_leaves_to(
+                other_contracts.resource_calendar_id.transfer_leaves_to(
                     contract.resource_calendar_id,
                     resources=contract.employee_id.resource_id,
                     from_date=contract.date_start,
                 )
-            # Update Overtime
-            all_contracts.action_update_overtime()
+        # Update Overtime
+        self.contract_ids.action_update_overtime()

--- a/hr_contract_update_overtime/readme/DESCRIPTION.md
+++ b/hr_contract_update_overtime/readme/DESCRIPTION.md
@@ -5,3 +5,6 @@ You can Update Overtime in different ways:
 - An action on the Contract History tree view
 - Header button on Contract History form view
 - Header button on Contract form view
+
+If you Update Overtime from Contract History, leaves will also be reorganized
+across their contract calendars.

--- a/hr_contract_update_overtime/static/description/index.html
+++ b/hr_contract_update_overtime/static/description/index.html
@@ -379,6 +379,8 @@ Overtime.</p>
 <li>Header button on Contract History form view</li>
 <li>Header button on Contract form view</li>
 </ul>
+<p>If you Update Overtime from Contract History, leaves will also be
+reorganized across their contract calendars.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.

--- a/hr_contract_update_overtime/tests/test_hr_contract_update_overtime.py
+++ b/hr_contract_update_overtime/tests/test_hr_contract_update_overtime.py
@@ -196,6 +196,35 @@ class HRContractUpdateOvertime(TransactionCase):
                 ("employee_id", "=", cls.employee.id),
             ]
         )
+        # Create all leaves on last contract
+        cls.env["resource.calendar.leaves"].create(
+            [
+                {
+                    "name": "Test Leave 2h",
+                    "date_from": make_dtt(4, h=8, m=0),
+                    "date_to": make_dtt(4, h=8, m=30),
+                    "resource_id": cls.employee.resource_id.id,
+                    "calendar_id": rc_8h_day.id,
+                    "company_id": company.id,
+                },
+                {
+                    "name": "Test Leave 4h",
+                    "date_from": make_dtt(3, h=8, m=0),
+                    "date_to": make_dtt(3, h=8, m=30),
+                    "resource_id": cls.employee.resource_id.id,
+                    "calendar_id": rc_8h_day.id,
+                    "company_id": company.id,
+                },
+                {
+                    "name": "Test Leave 8h",
+                    "date_from": make_dtt(2, h=8, m=0),
+                    "date_to": make_dtt(2, h=8, m=30),
+                    "resource_id": cls.employee.resource_id.id,
+                    "calendar_id": rc_8h_day.id,
+                    "company_id": company.id,
+                },
+            ]
+        )
         cls.overtime_model = cls.env["hr.attendance.overtime"]
 
     def test_overtime(self):
@@ -210,4 +239,8 @@ class HRContractUpdateOvertime(TransactionCase):
             )
             .mapped("duration")
         )
-        self.assertEqual(sum(total_overtime), -3.0)
+        # Check Overtime
+        self.assertEqual(sum(total_overtime), -1.5)
+        # Check Leaves has been moved correctly
+        for contract in self.contract_history.contract_ids:
+            self.assertEqual(len(contract.resource_calendar_id.leave_ids), 1)

--- a/hr_contract_update_overtime/views/hr_contract_history_view.xml
+++ b/hr_contract_update_overtime/views/hr_contract_history_view.xml
@@ -13,6 +13,7 @@
                     type="object"
                     groups="hr_attendance.group_hr_attendance_user"
                     help="Update Overtime on Running and Expired contracts"
+                    confirm="This action will also reorganize all the Employee's leaves by distributing them across their contract calendars. If you do not want this to happen, you can Update Overtime from a specific contract."
                 />
             </xpath>
         </field>


### PR DESCRIPTION
- Note when Updating Overtime
- Reorganize leaves across Calendars when Update Overtime from Contract History

MT-6583 @moduon  @rafaelbn @loida-vm @fcvalgar please reivew if you want 😄 