### PR TITLE
[16.0][IMP] hr_attendance_report_theoretical_time: Add company compatibility in the report + Add Active employees filter to report

### DIFF
--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
@@ -20,6 +20,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
     employee_id = fields.Many2one(
         comodel_name="hr.employee", string="Employee", readonly=True
     )
+    company_id = fields.Many2one(related="employee_id.company_id")
     department_id = fields.Many2one(
         comodel_name="hr.department",
         string="Department",

--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
@@ -33,6 +33,12 @@
                     string="My Attendances"
                     domain="[('employee_id.user_id.id', '=', uid)]"
                 />
+                <separator />
+                <filter
+                    name="active_employees"
+                    string="Active employees"
+                    domain="[('employee_id.active', '=', True)]"
+                />
             </search>
         </field>
     </record>

--- a/hr_attendance_report_theoretical_time/security/hr_attendance_report_theoretical_time_security.xml
+++ b/hr_attendance_report_theoretical_time/security/hr_attendance_report_theoretical_time_security.xml
@@ -2,6 +2,11 @@
 <!-- Copyright 2018 Tecnativa - Pedro M. Baeza
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo noupdate="1">
+    <record id="rule_multi_company_theoretical_vs_worked_report" model="ir.rule">
+        <field name="name">Theoretical vs worked hours multi-company</field>
+        <field name="model_id" ref="model_hr_attendance_theoretical_time_report" />
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    </record>
     <record model="ir.rule" id="rule_theoretical_vs_worked_report_own">
         <field name="name">Theoretical vs worked hours: Own attendances</field>
         <field name="model_id" ref="model_hr_attendance_theoretical_time_report" />


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/hr-attendance/pull/186

Changes done:
- [x] Add company compatibility in the report
- [x] Add Active employees filter to report

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT51401