### PR TITLE
[15.0[FIX] hr_attendance_reason: show reasons config to attendance admins

### DIFF
--- a/hr_attendance_reason/views/hr_attendance_reason_view.xml
+++ b/hr_attendance_reason/views/hr_attendance_reason_view.xml
@@ -57,4 +57,10 @@
         sequence="110"
         groups="hr_attendance.group_hr_attendance_manager"
     />
+    <record id="hr_attendance.menu_hr_attendance_settings" model="ir.ui.menu">
+        <!-- We need to leave the action empty for consistency because we are going
+            to set different submenus, otherwise the configuration menu would not be
+            displayed to a basic user. !-->
+        <field name="action" eval="False" />
+    </record>
 </odoo>


### PR DESCRIPTION
Users with no settings config wasn't seeing the reasons config menu even having the attendances admin settings.

cc @Tecnativa TT40775

please review @pedrobaeza @victoralmau 