### PR TITLE
[17.0][FIX] hr_attendance_reason: remove 'manual_selection' route

### DIFF
--- a/hr_attendance_reason/controllers/main.py
+++ b/hr_attendance_reason/controllers/main.py
@@ -22,7 +22,6 @@ class HrAttendance(HrAttendance):
             )
         return super().systray_attendance(latitude=latitude, longitude=longitude)
 
-    @route("/hr_attendance/manual_selection", type="json", auth="public")
     def manual_selection(self, token, employee_id, pin_code):
         if request.params.get("attendance_reason_id"):
             request.update_context(


### PR DESCRIPTION
[FIX] hr_attendance_reason: remove 'manual_selection' route

Steps to reproduce
In kiosk mode, after installing hr_attendance_reason, restart Odoo without configuring any Reason or enabling "Show reasons on attendance screen?"

Current behavior
When opening the public kiosk URL, I select an Employee, then enter the PIN. Upon clicking OK, it shows a notification "Connection lost", followed shortly by "Connection restored", but nothing happens. It remains on the numeric keypad screen to enter the PIN.

This is the log after installing the module:
2025-02-19 16:44:07,162 2700 INFO ? odoo.modules.loading: 1 modules loaded in 0.01s, 0 queries (+0 extra)
2025-02-19 16:44:07,193 2700 INFO ? odoo.modules.loading: loading 55 modules...
2025-02-19 16:44:07,539 2700 INFO ? odoo.modules.loading: 55 modules loaded in 0.35s, 0 queries (+0 extra)
2025-02-19 16:44:07,646 2700 INFO ? odoo.modules.loading: Modules loaded.
2025-02-19 16:44:07,650 2700 INFO ? odoo.modules.registry: Registry loaded in 0.509s
2025-02-19 16:44:07,651 2700 INFO rjl odoo.addons.base.models.ir_http: Generating routing map for key None
2025-02-19 16:44:07,658 2700 WARNING rjl odoo.http: The endpoint odoo.addons.hr_attendance.controllers.main.HrAttendance.manual_selection is not decorated by @route(), decorating it myself.
2025-02-19 16:44:07,658 2700 WARNING rjl odoo.http: The endpoint odoo.addons.hr_attendance_reason.controllers.main.HrAttendance.manual_selection changes the route type, using the original type: 'http'.
2025-02-19 16:44:08,067 2700 INFO ? odoo.addons.bus.models.bus: Bus.loop listen imbus on db postgres

This is the log at the time of the error:
2025-02-19 16:46:08,469 2698 WARNING rjl odoo.http: No CSRF validation token provided for path '/hr_attendance/manual_selection'