### PR TITLE
[16.0][FIX] hr_attendance_geolocation: correctly display the seconds symbol

### DIFF
--- a/hr_attendance_geolocation/models/hr_attendance.py
+++ b/hr_attendance_geolocation/models/hr_attendance.py
@@ -29,7 +29,7 @@ class HrAttendance(models.Model):
         m = int((dd - d) * 60)
         s = (dd - d - m / 60) * 3600.00
         z = round(s, 2)
-        return "%sº %s' %s'" % (abs(d), abs(m), abs(z))
+        return "%sº %s' %s\"" % (abs(d), abs(m), abs(z))
 
     def _get_latitude_raw_value(self, dd):
         return "%s %s" % (


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/hr-attendance/pull/209

Currently seconds are shown with the minute symbol, making it difficult to operate with the values, e.g. copy and paste them into Google Maps.

@Tecnativa