### PR TITLE
[18.0][FIX] hr_attendance_reason: parse reason ID from string to integer

### DIFF
--- a/hr_attendance_reason/controllers/main.py
+++ b/hr_attendance_reason/controllers/main.py
@@ -35,7 +35,7 @@ class HrAttendance(HrAttendance):
     def systray_attendance(self, latitude=False, longitude=False):
         if request.params.get("attendance_reason_id"):
             request.update_context(
-                attendance_reason_id=request.params.get("attendance_reason_id")
+                attendance_reason_id=int(request.params.get("attendance_reason_id"))
             )
         return super().systray_attendance(latitude=latitude, longitude=longitude)
 
@@ -45,7 +45,7 @@ class HrAttendance(HrAttendance):
     ):
         if request.params.get("attendance_reason_id"):
             request.update_context(
-                attendance_reason_id=request.params.get("attendance_reason_id")
+                attendance_reason_id=int(request.params.get("attendance_reason_id"))
             )
         return super().manual_selection_with_geolocation(
             token, employee_id, pin_code, latitude, longitude


### PR DESCRIPTION
[FIX] hr_attendance_reason: parse reason ID from string to integer before adding them to context

In the JavaScript part of the module, the ID of the selected attendance reason is processed as a string. When passing it to Python in the controllers "systray_check_in_out" and "manual_selection" as a context, the ID has not yet been converted to an integer. As a result, the ID was also added as a string when the attendance reason was added in the "_attendance_action_change" method. Even if this is not really clean, Odoo was still able to deal with it and finally added the reason for absence to the attendance entry.

However, this uncleanliness causes problems if you extend the write method of the attendance and try to access the newly written attendance reason after calling the super method. Odoo throws an error message, that he cannot locate the dataset with the ID as a string. We noticed this during a further extension of the module and would suggest parsing the ID directly as an integer to avoid such problems.