### PR TITLE
[15.0][FIX] hr_attendance_reason: Reasons are not displayed when the user who opens the kiosk does not have an associated employee

### DIFF
--- a/hr_attendance_reason/static/src/js/kiosk_confirm.esm.js
+++ b/hr_attendance_reason/static/src/js/kiosk_confirm.esm.js
@@ -20,9 +20,9 @@ KioskConfirm.include({
         await this._super();
         await this._rpc({
             model: "hr.employee",
-            method: "search_read",
+            method: "read",
             args: [
-                [["user_id", "=", this.getSession().uid]],
+                this.employee_id,
                 [
                     "show_reason_on_attendance_screen",
                     "required_reason_on_attendance_screen",


### PR DESCRIPTION
cc @Tecnativa 