### PR TITLE
[17.0][FIX] hr_attendance_report_theoretical_time: Solve ACLs error in kiosk/public check-in flows

### DIFF
--- a/hr_attendance_report_theoretical_time/models/hr_attendance.py
+++ b/hr_attendance_report_theoretical_time/models/hr_attendance.py
@@ -1,7 +1,7 @@
 # Copyright 2017-2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import SUPERUSER_ID, api, fields, models
 
 
 class HrAttendance(models.Model):
@@ -14,7 +14,7 @@ class HrAttendance(models.Model):
     @api.depends("check_in", "employee_id")
     def _compute_theoretical_hours(self):
         obj = self.env["hr.attendance.theoretical.time.report"]
-        for record in self:
+        for record in self.with_user(SUPERUSER_ID):
             record.theoretical_hours = obj._theoretical_hours(
                 record.employee_id, record.check_in
             )


### PR DESCRIPTION
**When attendance is created from kiosk/public flows, computing theoretical_hours may hit ACLs on working calendar details and crash check-in/check-out.
This patch computes theoretical hours as superuser in _compute_theoretical_hours to keep the reporting field computation from blocking attendance operations.
No business logic change, only execution context hardening for this compute.**

**Error to solve on kiosk check-in:**

<img width="853" height="641" alt="image" src="https://github.com/user-attachments/assets/9d5e0992-13df-4679-8d5d-1f5e3e2942bb" />

