### PR TITLE
[16.0][ADD] hr_timesheet_attendance_hours: attendance hours on timesheet lines

### DIFF
--- a/hr_timesheet_attendance_hours/README.md
+++ b/hr_timesheet_attendance_hours/README.md
@@ -1,0 +1,46 @@
+# Timesheet - Attendance Hours
+
+[![License: AGPL-3](https://img.shields.io/badge/licence-AGPL--3-blue.svg)](http://www.gnu.org/licenses/agpl-3.0-standalone.html)
+
+Adds an **Attendance Hours** column to timesheet lines with color-coded status.
+
+## Use Case
+
+The timekeeper logs daily work hours across multiple tasks. This module cross-references
+against actual attendance from access control (turnstile / biometric / facial
+recognition), highlighting discrepancies with colors.
+
+## Color Logic
+
+Compares total daily timesheet hours vs physical attendance:
+
+- **Green**: Attendance > timesheet + 30min (normal, includes lunch break)
+- **Yellow**: Attendance ≈ timesheet (within 30min margin)
+- **Red**: Attendance < timesheet (logged more hours than physically present)
+
+Works correctly with multiple tasks per day (3h Task A + 6h Task B = 9h total compared
+against attendance).
+
+## Fields Added
+
+- `attendance_hours` — physical presence from `hr.attendance`
+- `daily_timesheet_hours` — sum of all timesheet entries for that employee/date
+
+## Dependencies
+
+- `hr_timesheet`
+- `hr_attendance`
+
+## Credits
+
+### Authors
+
+- Pop Solutions
+
+### Contributors
+
+- Marcos Méndez
+
+## License
+
+AGPL-3

--- a/hr_timesheet_attendance_hours/__init__.py
+++ b/hr_timesheet_attendance_hours/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/hr_timesheet_attendance_hours/__manifest__.py
+++ b/hr_timesheet_attendance_hours/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "Timesheet - Attendance Hours",
+    "version": "16.0.1.0.0",
+    "category": "Human Resources/Attendances",
+    "summary": "Show employee attendance hours on timesheet lines",
+    "author": "Pop Solutions, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/hr-attendance",
+    "license": "AGPL-3",
+    "depends": ["hr_timesheet", "hr_attendance"],
+    "data": ["views/account_analytic_line_views.xml"],
+    "installable": True,
+    "auto_install": False,
+}

--- a/hr_timesheet_attendance_hours/models/__init__.py
+++ b/hr_timesheet_attendance_hours/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_analytic_line

--- a/hr_timesheet_attendance_hours/models/account_analytic_line.py
+++ b/hr_timesheet_attendance_hours/models/account_analytic_line.py
@@ -1,0 +1,100 @@
+from odoo import api, fields, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = "account.analytic.line"
+
+    attendance_hours = fields.Float(
+        compute="_compute_attendance_hours",
+        digits=(16, 2),
+        help="Total hours the employee was present according to "
+        "HR Attendance (turnstile/biometric) on this date.",
+    )
+    daily_timesheet_hours = fields.Float(
+        compute="_compute_attendance_hours",
+        digits=(16, 2),
+        help="Total timesheet hours for this employee on this date.",
+    )
+    attendance_status = fields.Selection(
+        [
+            ("ok", "OK"),
+            ("warn", "~"),
+            ("over", "OVER"),
+            ("none", "-"),
+        ],
+        compute="_compute_attendance_hours",
+        help="Compares total daily timesheet vs attendance hours.",
+    )
+
+    @api.depends("employee_id", "date", "unit_amount")
+    def _compute_attendance_hours(self):
+        emp_ids = set()
+        dates = set()
+        for line in self:
+            if line.employee_id and line.date:
+                emp_ids.add(line.employee_id.id)
+                dates.add(line.date)
+
+        if not emp_ids or not dates:
+            for line in self:
+                line.attendance_hours = 0.0
+                line.daily_timesheet_hours = 0.0
+                line.attendance_status = "none"
+            return
+
+        tz = self.env.user.tz or "UTC"
+
+        self.env.cr.execute(
+            """
+            SELECT
+                employee_id,
+                (check_in AT TIME ZONE 'UTC' AT TIME ZONE %(tz)s)::date AS att_date,
+                SUM(worked_hours) AS total_hours
+            FROM hr_attendance
+            WHERE
+                check_out IS NOT NULL
+                AND employee_id IN %(emp_ids)s
+                AND (check_in AT TIME ZONE 'UTC' AT TIME ZONE %(tz)s)::date
+                    IN %(dates)s
+            GROUP BY employee_id, att_date
+            """,
+            {"tz": tz, "emp_ids": tuple(emp_ids), "dates": tuple(dates)},
+        )
+        att_map = {(row[0], row[1]): row[2] or 0.0 for row in self.env.cr.fetchall()}
+
+        self.env.cr.execute(
+            """
+            SELECT
+                employee_id,
+                date,
+                SUM(unit_amount) AS total_hours
+            FROM account_analytic_line
+            WHERE
+                employee_id IN %(emp_ids)s
+                AND date IN %(dates)s
+                AND project_id IS NOT NULL
+            GROUP BY employee_id, date
+            """,
+            {"emp_ids": tuple(emp_ids), "dates": tuple(dates)},
+        )
+        ts_map = {(row[0], row[1]): row[2] or 0.0 for row in self.env.cr.fetchall()}
+
+        for line in self:
+            if line.employee_id and line.date:
+                key = (line.employee_id.id, line.date)
+                att = att_map.get(key, 0.0)
+                ts = ts_map.get(key, 0.0)
+                line.attendance_hours = att
+                line.daily_timesheet_hours = ts
+                if att <= 0:
+                    line.attendance_status = "none"
+                elif att < ts:
+                    line.attendance_status = "over"
+                elif att < ts + 0.5:
+                    line.attendance_status = "warn"
+                else:
+                    line.attendance_status = "ok"
+            else:
+                line.attendance_hours = 0.0
+                line.daily_timesheet_hours = 0.0
+                line.attendance_status = "none"

--- a/hr_timesheet_attendance_hours/tests/__init__.py
+++ b/hr_timesheet_attendance_hours/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_timesheet_attendance_hours

--- a/hr_timesheet_attendance_hours/tests/test_timesheet_attendance_hours.py
+++ b/hr_timesheet_attendance_hours/tests/test_timesheet_attendance_hours.py
@@ -1,0 +1,122 @@
+from datetime import date, datetime
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestTimesheetAttendanceHours(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.tz = "UTC"
+        cls.company = cls.env.ref("base.main_company")
+        cls.employee = cls.env["hr.employee"].create(
+            {"name": "Test Worker", "company_id": cls.company.id}
+        )
+        cls.project = cls.env["project.project"].create(
+            {"name": "Test Project", "company_id": cls.company.id}
+        )
+        cls.today = date.today()
+        cls.base = datetime.combine(cls.today, datetime.min.time())
+
+    def _make_attendance(self, hour_in, hour_out):
+        return self.env["hr.attendance"].create(
+            {
+                "employee_id": self.employee.id,
+                "check_in": self.base.replace(hour=hour_in),
+                "check_out": self.base.replace(hour=hour_out),
+            }
+        )
+
+    def _make_timesheet(self, hours, name="Task"):
+        return self.env["account.analytic.line"].create(
+            {
+                "name": name,
+                "employee_id": self.employee.id,
+                "project_id": self.project.id,
+                "date": self.today,
+                "unit_amount": hours,
+            }
+        )
+
+    def test_attendance_hours_basic(self):
+        self._make_attendance(9, 17)
+        line = self._make_timesheet(6.0)
+        self.env.flush_all()
+        line.invalidate_recordset()
+        self.assertAlmostEqual(line.attendance_hours, 8.0, places=1)
+
+    def test_no_attendance_zero(self):
+        line = self._make_timesheet(4.0)
+        self.assertEqual(line.attendance_hours, 0.0)
+
+    def test_multiple_attendances_summed(self):
+        self._make_attendance(8, 12)
+        self._make_attendance(13, 17)
+        line = self._make_timesheet(8.0)
+        self.env.flush_all()
+        line.invalidate_recordset()
+        self.assertAlmostEqual(line.attendance_hours, 8.0, places=1)
+
+    def test_open_attendance_excluded(self):
+        self.env["hr.attendance"].create(
+            {
+                "employee_id": self.employee.id,
+                "check_in": self.base.replace(hour=9),
+            }
+        )
+        line = self._make_timesheet(4.0)
+        self.assertEqual(line.attendance_hours, 0.0)
+
+    def test_different_employees_independent(self):
+        other = self.env["hr.employee"].create(
+            {"name": "Other", "company_id": self.company.id}
+        )
+        self.env["hr.attendance"].create(
+            {
+                "employee_id": other.id,
+                "check_in": self.base.replace(hour=9),
+                "check_out": self.base.replace(hour=17),
+            }
+        )
+        line = self._make_timesheet(8.0)
+        self.assertEqual(line.attendance_hours, 0.0)
+
+    def test_daily_timesheet_hours_single(self):
+        self._make_attendance(9, 17)
+        line = self._make_timesheet(6.0)
+        self.env.flush_all()
+        line.invalidate_recordset()
+        self.assertAlmostEqual(line.daily_timesheet_hours, 6.0, places=1)
+
+    def test_daily_timesheet_hours_multiple_tasks(self):
+        self._make_attendance(9, 18)
+        line1 = self._make_timesheet(3.0, "Task 1")
+        line2 = self._make_timesheet(6.0, "Task 2")
+        self.env.flush_all()
+        (line1 | line2).invalidate_recordset()
+        self.assertAlmostEqual(line1.daily_timesheet_hours, 9.0, places=1)
+        self.assertAlmostEqual(line2.daily_timesheet_hours, 9.0, places=1)
+        self.assertAlmostEqual(line1.attendance_hours, 9.0, places=1)
+
+    def test_color_green(self):
+        self._make_attendance(8, 18)
+        line = self._make_timesheet(9.0)
+        self.env.flush_all()
+        line.invalidate_recordset()
+        self.assertGreater(line.attendance_hours, line.daily_timesheet_hours + 0.5)
+
+    def test_color_yellow(self):
+        self._make_attendance(9, 18)
+        line = self._make_timesheet(9.0)
+        self.env.flush_all()
+        line.invalidate_recordset()
+        self.assertGreaterEqual(line.attendance_hours, line.daily_timesheet_hours)
+        self.assertLess(line.attendance_hours, line.daily_timesheet_hours + 0.5)
+
+    def test_color_red(self):
+        self._make_attendance(9, 16)
+        line = self._make_timesheet(9.0)
+        self.env.flush_all()
+        line.invalidate_recordset()
+        self.assertLess(line.attendance_hours, line.daily_timesheet_hours)

--- a/hr_timesheet_attendance_hours/views/account_analytic_line_views.xml
+++ b/hr_timesheet_attendance_hours/views/account_analytic_line_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="hr_timesheet_line_tree_user_attendance" model="ir.ui.view">
+        <field name="name">account.analytic.line.tree.user.attendance_hours</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="hr_timesheet.timesheet_view_tree_user" />
+        <field name="arch" type="xml">
+            <field name="unit_amount" position="after">
+                <field name="attendance_hours" widget="float_time" optional="show" />
+                <field
+                    name="attendance_status"
+                    widget="badge"
+                    optional="show"
+                    decoration-danger="attendance_status == 'over'"
+                    decoration-warning="attendance_status == 'warn'"
+                    decoration-success="attendance_status == 'ok'"
+                />
+                <field
+                    name="daily_timesheet_hours"
+                    widget="float_time"
+                    optional="hide"
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/hr_timesheet_attendance_hours/odoo/addons/hr_timesheet_attendance_hours
+++ b/setup/hr_timesheet_attendance_hours/odoo/addons/hr_timesheet_attendance_hours
@@ -1,0 +1,1 @@
+../../../../hr_timesheet_attendance_hours

--- a/setup/hr_timesheet_attendance_hours/setup.py
+++ b/setup/hr_timesheet_attendance_hours/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Shows, on each timesheet line, the hours actually clocked by the employee on
that day, so recorded work can be compared against the attendance coming from
the turnstile.

Split out of #262, where it had been included by mistake alongside an
unrelated module.

Marked as draft: the module still needs tests before it is ready for review.
