### PR TITLE
[18.0][FIX] hr_attendance_report_theoretical_time: Avoid overlap empty attendances multi-date

### DIFF
--- a/hr_attendance_report_theoretical_time/models/hr_employee.py
+++ b/hr_attendance_report_theoretical_time/models/hr_employee.py
@@ -1,6 +1,6 @@
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 from dateutil.relativedelta import relativedelta
 from pytz import timezone, utc
@@ -68,14 +68,27 @@ class HrEmployee(models.Model):
         )
         # It's important to take both check_in and check_out into account because
         # (although strange) there could be an error where check_in=date1 and
-        # check_out=date2; in that case, we don't want to create a record for date2
-        # because they would overlap.
+        # check_out=date3; in that case, we don't want to create a record for date2
+        # and date3 because they would overlap.
         attendance_dates = sorted(
             {
-                dt.date()
+                fields.Datetime.context_timestamp(
+                    attendance, attendance.check_in
+                ).date()
+                + timedelta(days=i)
                 for attendance in items
-                for dt in (attendance.check_in, attendance.check_out)
-                if dt
+                if attendance.check_in
+                for i in range(
+                    (
+                        fields.Datetime.context_timestamp(
+                            attendance, (attendance.check_out or attendance.check_in)
+                        ).date()
+                        - fields.Datetime.context_timestamp(
+                            attendance, attendance.check_in
+                        ).date()
+                    ).days
+                    + 1
+                )
             }
         )
         dates_to_create = {}

--- a/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
@@ -281,18 +281,18 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
             {
                 "employee_id": self.employee_1.id,
                 "check_in": "1946-12-23 08:00:00",
-                "check_out": "1946-12-24 12:00:00",
+                "check_out": "1946-12-25 12:00:00",
             }
         )
         attendance_model.action_create_empty_attendance(
             limit_date_from=datetime.date(1946, 12, 23),
-            limit_date_to=datetime.date(1946, 12, 25),
+            limit_date_to=datetime.date(1946, 12, 26),
         ).flush_recordset()
         domain = [
             ("employee_id", "=", self.employee_1.id),
             ("active", "=", False),
             ("check_in", ">=", "1946-12-23"),
-            ("check_in", "<=", "1946-12-25"),
+            ("check_in", "<=", "1946-12-26"),
         ]
         attendance_model = self.env["hr.attendance"].with_context(active_test=False)
         total_items = attendance_model.search_count(domain)
@@ -301,10 +301,10 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
         attendance.write({"check_out": "1946-12-23 12:00:00"})
         attendance_model.action_create_empty_attendance(
             limit_date_from=datetime.date(1946, 12, 23),
-            limit_date_to=datetime.date(1946, 12, 25),
+            limit_date_to=datetime.date(1946, 12, 26),
         ).flush_recordset()
         total_items = attendance_model.search_count(domain)
-        self.assertEqual(total_items, 2)
+        self.assertEqual(total_items, 3)
 
     def test_change_hr_holidays_public(self):
         self.public_holiday_global.line_ids[0].write({"date": "1946-12-23"})


### PR DESCRIPTION
Avoid overlap empty attendances multi-date

If there is an attendance record with a check-out date (date3) later than the check-in date (date1), do not create an attendance record with that dates (date1, date2 and date3).

Related to https://github.com/OCA/hr-attendance/pull/294

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT64274