### PR TITLE
[19.0][FIX] hr_attendance_report_theoretical_time: Avoid overlap empty attendances

### DIFF
--- a/hr_attendance_report_theoretical_time/models/hr_employee.py
+++ b/hr_attendance_report_theoretical_time/models/hr_employee.py
@@ -1,6 +1,6 @@
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 from dateutil.relativedelta import relativedelta
 from pytz import timezone, utc
@@ -66,8 +66,30 @@ class HrEmployee(models.Model):
                 ]
             )
         )
+        # It's important to take both check_in and check_out into account because
+        # (although strange) there could be an error where check_in=date1 and
+        # check_out=date3; in that case, we don't want to create a record for date2
+        # and date3 because they would overlap.
         attendance_dates = sorted(
-            {check_in.date() for check_in in items.mapped("check_in")}
+            {
+                fields.Datetime.context_timestamp(
+                    attendance, attendance.check_in
+                ).date()
+                + timedelta(days=i)
+                for attendance in items
+                if attendance.check_in
+                for i in range(
+                    (
+                        fields.Datetime.context_timestamp(
+                            attendance, (attendance.check_out or attendance.check_in)
+                        ).date()
+                        - fields.Datetime.context_timestamp(
+                            attendance, attendance.check_in
+                        ).date()
+                    ).days
+                    + 1
+                )
+            }
         )
         dates_to_create = {}
         expected_attendances = self.resource_calendar_id._work_intervals_batch(

--- a/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
@@ -276,6 +276,40 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
         total_items = attendance_model.search_count(domain)
         self.assertEqual(total_items, 3)
 
+    @mute_logger("odoo.models.unlink")
+    @freeze_time("1947-01-01")
+    def test_hr_attendance_cron_theoretical_hours_start_date_multi_date(self):
+        attendance_model = self.env["hr.attendance"]
+        attendance_model.search([("employee_id", "=", self.employee_1.id)]).unlink()
+        attendance = attendance_model.create(
+            {
+                "employee_id": self.employee_1.id,
+                "check_in": "1946-12-23 08:00:00",
+                "check_out": "1946-12-25 12:00:00",
+            }
+        )
+        attendance_model.action_create_empty_attendance(
+            limit_date_from=datetime.date(1946, 12, 23),
+            limit_date_to=datetime.date(1946, 12, 26),
+        ).flush_recordset()
+        domain = [
+            ("employee_id", "=", self.employee_1.id),
+            ("active", "=", False),
+            ("check_in", ">=", "1946-12-23"),
+            ("check_in", "<=", "1946-12-26"),
+        ]
+        attendance_model = self.env["hr.attendance"].with_context(active_test=False)
+        total_items = attendance_model.search_count(domain)
+        self.assertEqual(total_items, 1)
+        # Fix wrong check_out date
+        attendance.write({"check_out": "1946-12-23 12:00:00"})
+        attendance_model.action_create_empty_attendance(
+            limit_date_from=datetime.date(1946, 12, 23),
+            limit_date_to=datetime.date(1946, 12, 26),
+        ).flush_recordset()
+        total_items = attendance_model.search_count(domain)
+        self.assertEqual(total_items, 3)
+
     def test_change_hr_holidays_public(self):
         self.public_holiday_global.line_ids[0].write({"date": "1946-12-23"})
         # 1946-12-23


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/hr-attendance/pull/294 + https://github.com/OCA/hr-attendance/pull/296

Avoid overlap empty attendances

If there is an attendance record with a check-out date later than the check-in date, do not create an attendance record with that date.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT64274