### PR TITLE
[18.0][IMP+FIX] hr_attendance_report_theoretical_time: Empty Attendance Records improvements

### DIFF
--- a/hr_attendance_report_theoretical_time/models/hr_attendance.py
+++ b/hr_attendance_report_theoretical_time/models/hr_attendance.py
@@ -41,7 +41,7 @@ class HrAttendance(models.Model):
         The goal is to prevent the report from having to calculate data
         directly, so employee attendance records are created for past days
         when they should have clocked in."""
-        today = fields.Date.today()
+        today = fields.Date.context_today(self)
         yesterday = today - relativedelta(days=1)
         today_previous_year = today - relativedelta(months=1)
         limit_date_from = limit_date_from or today_previous_year
@@ -52,11 +52,7 @@ class HrAttendance(models.Model):
             .sudo()
             .search([("resource_calendar_id", "!=", False)])
         ):
-            date_from = (
-                employee.theoretical_hours_start_date or employee.create_date.date()
-            )
-            date_from = max(date_from, limit_date_from)
             attendances += employee._action_create_empty_attendance(
-                date_from, day_to.date()
+                limit_date_from, day_to.date()
             )
         return attendances

--- a/hr_attendance_report_theoretical_time/models/hr_employee.py
+++ b/hr_attendance_report_theoretical_time/models/hr_employee.py
@@ -50,8 +50,16 @@ class HrEmployee(models.Model):
         directly, so employee attendance records are created for past days
         when they should have clocked in."""
         self.ensure_one()
+        limit_date_from = (
+            self.theoretical_hours_start_date
+            or fields.Datetime.context_timestamp(self, self.create_date).date()
+        )
+        date_from = max(date_from, limit_date_from)
         day_from = datetime.combine(date_from, time.min)
         from_datetime = utc.localize(day_from).astimezone(timezone(self.tz or "UTC"))
+        today = fields.Date.context_today(self)
+        limit_date_to = today - relativedelta(days=1)
+        date_to = min(date_to, limit_date_to)
         day_to = datetime.combine(date_to, time.max)
         to_datetime = utc.localize(day_to).astimezone(timezone(self.tz or "UTC"))
         items = (

--- a/hr_attendance_report_theoretical_time/models/hr_employee.py
+++ b/hr_attendance_report_theoretical_time/models/hr_employee.py
@@ -29,7 +29,7 @@ class HrEmployee(models.Model):
             for item in self:
                 date_from = (
                     item.theoretical_hours_start_date
-                    or fields.Datetime.context_timestamp(item.create_date).date()
+                    or fields.Datetime.context_timestamp(item, item.create_date).date()
                 )
                 attendance_model.sudo().search(
                     [

--- a/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
@@ -248,7 +248,7 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
         self.assertEqual(res[5]["theoretical_hours"], 8)  # 1946-12-30(virtual)
 
     @mute_logger("odoo.models.unlink")
-    @freeze_time("1947-01-01")
+    @freeze_time("1947-01-02")
     def test_hr_attendance_cron_theoretical_hours_start_date(self):
         self.env["hr.attendance"].action_create_empty_attendance(
             limit_date_from=datetime.date(1946, 12, 23),

--- a/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance.py
+++ b/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance.py
@@ -12,6 +12,7 @@ class RecomputeTheoreticalAttendance(models.TransientModel):
         required=True,
         string="Employees",
         help="Recompute these employees attendances",
+        context={"active_test": False},
     )
     date_from = fields.Datetime(
         string="From", required=True, help="Recompute attendances from this date"

--- a/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance.py
+++ b/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance.py
@@ -28,6 +28,10 @@ class RecomputeTheoreticalAttendance(models.TransientModel):
 
     def action_recompute(self):
         self.ensure_one()
+        for employee in self.employee_ids:
+            employee._action_create_empty_attendance(
+                self.date_from.date(), self.date_to.date()
+            )
         attendances = (
             self.env["hr.attendance"]
             .with_context(active_test=False)

--- a/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance_views.xml
+++ b/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance_views.xml
@@ -20,8 +20,13 @@
                             context="{'active_test': True}"
                             widget="many2many_tags"
                         />
-                        <field name="date_from" />
-                        <field name="date_to" />
+                        <field
+                            name="date_from"
+                            string="Dates"
+                            widget="daterange"
+                            options="{'end_date_field': 'date_to'}"
+                        />
+                        <field name="date_to" invisible="1" />
                     </group>
                 </group>
                 <footer>

--- a/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance_views.xml
+++ b/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance_views.xml
@@ -15,7 +15,11 @@
             <form>
                 <group>
                     <group>
-                        <field name="employee_ids" widget="many2many_tags" />
+                        <field
+                            name="employee_ids"
+                            context="{'active_test': True}"
+                            widget="many2many_tags"
+                        />
                         <field name="date_from" />
                         <field name="date_to" />
                     </group>


### PR DESCRIPTION
Changes done:
- [x] Display the selected archived employee
- [x] Add `widget="daterange"` to Recompute Theoretical Attendances wizard
- [x] Create Empty Attendance Records in the Recompute Theoretical Attendances Wizard
- [x] Avoid errors when editing an employee

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa