### PR TITLE
[19.0][IMP] hr_attendance_report_theoretical_time: Add leave hours column to report

### DIFF
--- a/hr_attendance_report_theoretical_time/README.rst
+++ b/hr_attendance_report_theoretical_time/README.rst
@@ -45,12 +45,12 @@ types if specified in them.
 As an example, imagine a work week with 40 theoretical hours, and these
 attendance situation:
 
-- Monday: Worked 10 hours
-- Tuesday: Worked 10 hours
-- Wednesday: Worked 10 hours
-- Thursday: Worked 10 hours
-- Friday: Ask for a compensation leave (said leave type), as already
-  worked 40 hours.
+-  Monday: Worked 10 hours
+-  Tuesday: Worked 10 hours
+-  Wednesday: Worked 10 hours
+-  Thursday: Worked 10 hours
+-  Friday: Ask for a compensation leave (said leave type), as already
+   worked 40 hours.
 
 On the report, whole week should put 40 theoretical hours - 8 per day -
 against 40 worked hours (although they were on previous days, and none
@@ -88,11 +88,11 @@ For including some leave types in the theoretical time, you have to:
 When generating non worked days, this module uses a start date for
 beginning the series generation, which is:
 
-- Manual start date set on the employee.
-- If not set, the greatest of these 2 dates:
+-  Manual start date set on the employee.
+-  If not set, the greatest of these 2 dates:
 
-  - Employee creation date.
-  - Working calendar line start date.
+   -  Employee creation date.
+   -  Working calendar line start date.
 
 For configuring manual start date, you have to:
 
@@ -115,17 +115,17 @@ Usage
 Known issues / Roadmap
 ======================
 
-- Employees with less than 1 week in the company will show full week
-  theoretical hours.
-- Activate ORM cache for improving performance on computing theoretical
-  hours, but assuring that the cache is cleared when the conditions of
-  the computation changes.
-- If you change employee's working time, theoretical hours for non
-  attended days will be computed according this new calendar. You have
-  to define start and end dates inside the calendar for avoiding this
-  side effect.
-- Theoretical hours of affected days when changing the leave type to be
-  included or not in theoretical time are not recomputed.
+-  Employees with less than 1 week in the company will show full week
+   theoretical hours.
+-  Activate ORM cache for improving performance on computing theoretical
+   hours, but assuring that the cache is cleared when the conditions of
+   the computation changes.
+-  If you change employee's working time, theoretical hours for non
+   attended days will be computed according this new calendar. You have
+   to define start and end dates inside the calendar for avoiding this
+   side effect.
+-  Theoretical hours of affected days when changing the leave type to be
+   included or not in theoretical time are not recomputed.
 
 Bug Tracker
 ===========
@@ -148,34 +148,34 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza.
-  - David Vidal
-  - Víctor Martínez
-  - Juan José Seguí
+   -  Pedro M. Baeza.
+   -  David Vidal
+   -  Víctor Martínez
+   -  Juan José Seguí
 
-- Pedro Gonzalez <pedro.gonzalez@pesol.es>
-- Aritz Olea <ao@landoo.es>
-- `Trobz <https://trobz.com>`__:
+-  Pedro Gonzalez <pedro.gonzalez@pesol.es>
+-  Aritz Olea <ao@landoo.es>
+-  `Trobz <https://trobz.com>`__:
 
-  - Dzung Tran <dungtd@trobz.com>
-  - Do Anh Duy <duyda@trobz.com>
+   -  Dzung Tran <dungtd@trobz.com>
+   -  Do Anh Duy <duyda@trobz.com>
 
-- `Dixmit <https://dixmit.com>`__
+-  `Dixmit <https://dixmit.com>`__
 
-  - Enric Tobella
+   -  Enric Tobella
 
 Other credits
 -------------
 
 **Images**
 
-- Font Awesome: `Icon <http://fontawesome.io>`__.
+-  Font Awesome: `Icon <http://fontawesome.io>`__.
 
 The development of this module has been financially supported by:
 
-- Camptocamp
+-  Camptocamp
 
 Maintainers
 -----------

--- a/hr_attendance_report_theoretical_time/__init__.py
+++ b/hr_attendance_report_theoretical_time/__init__.py
@@ -3,3 +3,4 @@
 from . import models
 from . import reports
 from . import wizards
+from .hooks import pre_init_hook

--- a/hr_attendance_report_theoretical_time/__manifest__.py
+++ b/hr_attendance_report_theoretical_time/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Theoretical vs Attended Time Analysis",
-    "version": "19.0.1.0.3",
+    "version": "19.0.1.1.0",
     "category": "Human Resources",
     "website": "https://github.com/OCA/hr-attendance",
     "author": "Tecnativa, Odoo Community Association (OCA)",
@@ -20,4 +20,5 @@
         "wizards/recompute_theoretical_attendance_views.xml",
         "wizards/wizard_theoretical_time.xml",
     ],
+    "pre_init_hook": "pre_init_hook",
 }

--- a/hr_attendance_report_theoretical_time/hooks.py
+++ b/hr_attendance_report_theoretical_time/hooks.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tools.sql import column_exists
+
+
+def pre_init_hook(env):
+    if not column_exists(env.cr, "hr_attendance", "leave_hours"):
+        env.cr.execute(
+            """
+            ALTER TABLE hr_attendance
+            ADD COLUMN IF NOT EXISTS leave_hours double precision
+            """,
+        )
+        env.cr.execute("UPDATE hr_attendance SET leave_hours = 0")
+    if not column_exists(env.cr, "hr_attendance", "theoretical_hours"):
+        env.cr.execute(
+            """
+            ALTER TABLE hr_attendance
+            ADD COLUMN IF NOT EXISTS theoretical_hours double precision
+            """,
+        )
+        env.cr.execute("UPDATE hr_attendance SET theoretical_hours = 0")

--- a/hr_attendance_report_theoretical_time/i18n/es.po
+++ b/hr_attendance_report_theoretical_time/i18n/es.po
@@ -177,6 +177,15 @@ msgid "ID"
 msgstr "ID"
 
 #. module: hr_attendance_report_theoretical_time
+#: model:ir.model.fields,help:hr_attendance_report_theoretical_time.field_hr_leave_type__include_in_leave_theoretical
+msgid ""
+"If you check this mark, leaves in this category won't reduce the number of "
+"leave hours in the attendance report."
+msgstr ""
+"Si marca esta casilla, las ausencias de este tipo no reduciran el número de "
+"horas de ausencia en el informe de asistencia."
+
+#. module: hr_attendance_report_theoretical_time
 #: model:ir.model.fields,help:hr_attendance_report_theoretical_time.field_hr_leave_type__include_in_theoretical
 msgid ""
 "If you check this mark, leaves in this category won't reduce the number of "
@@ -184,6 +193,11 @@ msgid ""
 msgstr ""
 "Si marca esta casilla, las ausencias de este tipo no reduciran el número de "
 "horas teóricas en el informe de asistencia."
+
+#. module: hr_attendance_report_theoretical_time
+#: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_hr_leave_type__include_in_leave_theoretical
+msgid "Include in leave hours"
+msgstr "Incluir en horas de ausencia"
 
 #. module: hr_attendance_report_theoretical_time
 #: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_hr_leave_type__include_in_theoretical
@@ -201,6 +215,16 @@ msgstr "Última modificación por"
 #: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_wizard_theoretical_time__write_date
 msgid "Last Updated on"
 msgstr "Última modificación en"
+
+#. module: hr_attendance_report_theoretical_time
+#: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_hr_attendance_theoretical_time_report__leave_hours
+msgid "Leave"
+msgstr "Ausencia"
+
+#. module: hr_attendance_report_theoretical_time
+#: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_hr_attendance__leave_hours
+msgid "Leave Hours"
+msgstr "Horas ausencia"
 
 #. module: hr_attendance_report_theoretical_time
 #: model_terms:ir.ui.view,arch_db:hr_attendance_report_theoretical_time.hr_attendance_theoretical_view_filter

--- a/hr_attendance_report_theoretical_time/i18n/hr_attendance_report_theoretical_time.pot
+++ b/hr_attendance_report_theoretical_time/i18n/hr_attendance_report_theoretical_time.pot
@@ -169,10 +169,22 @@ msgid "ID"
 msgstr ""
 
 #. module: hr_attendance_report_theoretical_time
+#: model:ir.model.fields,help:hr_attendance_report_theoretical_time.field_hr_leave_type__include_in_leave_theoretical
+msgid ""
+"If you check this mark, leaves in this category won't reduce the number of "
+"leave hours in the attendance report."
+msgstr ""
+
+#. module: hr_attendance_report_theoretical_time
 #: model:ir.model.fields,help:hr_attendance_report_theoretical_time.field_hr_leave_type__include_in_theoretical
 msgid ""
 "If you check this mark, leaves in this category won't reduce the number of "
 "theoretical hours in the attendance report."
+msgstr ""
+
+#. module: hr_attendance_report_theoretical_time
+#: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_hr_leave_type__include_in_leave_theoretical
+msgid "Include in leave hours"
 msgstr ""
 
 #. module: hr_attendance_report_theoretical_time
@@ -190,6 +202,16 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_recompute_theoretical_attendance__write_date
 #: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_wizard_theoretical_time__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: hr_attendance_report_theoretical_time
+#: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_hr_attendance_theoretical_time_report__leave_hours
+msgid "Leave"
+msgstr ""
+
+#. module: hr_attendance_report_theoretical_time
+#: model:ir.model.fields,field_description:hr_attendance_report_theoretical_time.field_hr_attendance__leave_hours
+msgid "Leave Hours"
 msgstr ""
 
 #. module: hr_attendance_report_theoretical_time

--- a/hr_attendance_report_theoretical_time/migrations/19.0.1.1.0/pre-migration.py
+++ b/hr_attendance_report_theoretical_time/migrations/19.0.1.1.0/pre-migration.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.add_columns(env, [("hr.attendance", "leave_hours", "float")])

--- a/hr_attendance_report_theoretical_time/models/hr_attendance.py
+++ b/hr_attendance_report_theoretical_time/models/hr_attendance.py
@@ -1,5 +1,5 @@
 # Copyright 2017-2019 Tecnativa - Pedro M. Baeza
-# Copyright 2025 Tecnativa - Víctor Martínez
+# Copyright 2025-2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from datetime import datetime, time
 
@@ -12,9 +12,18 @@ class HrAttendance(models.Model):
     _inherit = "hr.attendance"
 
     active = fields.Boolean(default=True)
+    leave_hours = fields.Float(
+        compute="_compute_leave_hours", store=True, compute_sudo=True
+    )
     theoretical_hours = fields.Float(
         compute="_compute_theoretical_hours", store=True, compute_sudo=True
     )
+
+    @api.depends("check_in", "employee_id")
+    def _compute_leave_hours(self):
+        obj = self.env["hr.attendance.theoretical.time.report"]
+        for record in self:
+            record.leave_hours = obj._leave_hours(record.employee_id, record.check_in)
 
     @api.depends("check_in", "employee_id")
     def _compute_theoretical_hours(self):

--- a/hr_attendance_report_theoretical_time/models/hr_leave_type.py
+++ b/hr_attendance_report_theoretical_time/models/hr_leave_type.py
@@ -12,3 +12,8 @@ class HrLeaveType(models.Model):
         help="If you check this mark, leaves in this category won't reduce "
         "the number of theoretical hours in the attendance report.",
     )
+    include_in_leave_theoretical = fields.Boolean(
+        string="Include in leave hours",
+        help="If you check this mark, leaves in this category won't reduce "
+        "the number of leave hours in the attendance report.",
+    )

--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
@@ -27,6 +27,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
         readonly=True,
     )
     date = fields.Date(readonly=True)
+    leave_hours = fields.Float(string="Leave", readonly=True)
     worked_hours = fields.Float(string="Worked", readonly=True)
     theoretical_hours = fields.Float(string="Theoric", readonly=True)
     difference = fields.Float(readonly=True)
@@ -39,6 +40,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
             min(id) AS id,
             employee_id,
             date,
+            max(leave_hours) AS leave_hours,
             sum(worked_hours) AS worked_hours,
             max(theoretical_hours) AS theoretical_hours,
             sum(worked_hours) - max(theoretical_hours) AS difference
@@ -52,6 +54,7 @@ class HrAttendanceTheoreticalTimeReport(models.Model):
             ha.id AS id,
             ha.employee_id AS employee_id,
             ha.check_in::date AS date,
+            ha.leave_hours AS leave_hours,
             CASE WHEN ha.active THEN ha.worked_hours ELSE 0 END AS worked_hours,
             ha.theoretical_hours AS theoretical_hours
             """
@@ -121,3 +124,34 @@ CREATE or REPLACE VIEW %s as (
             ],
         )
         return res[employee.id]["hours"]
+
+    @api.model
+    def _leave_hours(self, employee, date):
+        if not employee.resource_id.calendar_id:
+            return 0
+        tz = employee.resource_id.calendar_id.tz
+        from_datetime = datetime.combine(
+            date, time(0, 0, 0, 0, tzinfo=pytz.timezone(tz))
+        )
+        to_datetime = datetime.combine(
+            date, time(23, 59, 59, 99999, tzinfo=pytz.timezone(tz))
+        )
+        data1 = employee._get_work_days_data_batch(
+            from_datetime, to_datetime, compute_leaves=False
+        )
+        data2 = employee._get_work_days_data_batch(
+            from_datetime,
+            to_datetime,
+            compute_leaves=True,
+            # Pass this domain for excluding leaves whose type
+            domain=[
+                "|",
+                ("holiday_id", "=", False),
+                (
+                    "holiday_id.holiday_status_id.include_in_leave_theoretical",
+                    "=",
+                    False,
+                ),
+            ],
+        )
+        return data1[employee.id]["hours"] - data2[employee.id]["hours"]

--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report_views.xml
@@ -52,6 +52,7 @@
                 <field name="worked_hours" type="measure" widget="float_time" />
                 <field name="theoretical_hours" type="measure" widget="float_time" />
                 <field name="difference" type="measure" widget="float_time" />
+                <field name="leave_hours" type="measure" widget="float_time" />
             </pivot>
         </field>
     </record>

--- a/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
@@ -154,7 +154,9 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
         self.assertEqual(self.attendances[5].theoretical_hours, 0)
         # 1946-12-26 - Employee on Holidays
         self.assertEqual(self.attendances[6].theoretical_hours, 0)
+        self.assertEqual(self.attendances[6].leave_hours, 8)
         self.assertEqual(self.attendances[7].theoretical_hours, 0)
+        self.assertEqual(self.attendances[7].leave_hours, 8)
         # EMPLOYEE 2
         # 1946-12-23 - Public holidays for state of employee 2
         self.assertEqual(self.attendances[8].theoretical_hours, 0)
@@ -167,7 +169,9 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
         self.assertEqual(self.attendances[13].theoretical_hours, 0)
         # 1946-12-26 - Employee 2 leave
         self.assertEqual(self.attendances[14].theoretical_hours, 8)
+        self.assertEqual(self.attendances[14].leave_hours, 0)
         self.assertEqual(self.attendances[15].theoretical_hours, 8)
+        self.assertEqual(self.attendances[15].leave_hours, 0)
 
     @mute_logger("odoo.models.unlink")
     def test_theoretical_hours_recompute(self):
@@ -328,9 +332,11 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
     def test_hr_holidays_status_include_in_theoretical(self):
         obj = self.env["hr.attendance.theoretical.time.report"]
         self.leave.holiday_status_id.include_in_theoretical = True
+        self.leave.holiday_status_id.include_in_leave_theoretical = True
         # 1946-12-26 - Employee 1
         a = self.attendances[6]
         self.assertEqual(obj._theoretical_hours(a.employee_id, a.check_in), 8)
+        self.assertEqual(obj._leave_hours(a.employee_id, a.check_in), 0)
 
     def test_wizard_theoretical_time(self):
         department = self.env["hr.department"].create({"name": "Department"})
@@ -352,6 +358,7 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
     @mute_logger("odoo.models.unlink")
     def test_theoretical_recompute_on_unactive(self):
         self.assertEqual(self.attendances[0].theoretical_hours, 8)
+        self.assertEqual(self.attendances[0].leave_hours, 0)
         self.attendances[0].active = False
         leave = self.env["hr.leave"].create(
             {
@@ -365,6 +372,7 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
         )
         leave.action_approve()
         self.assertEqual(self.attendances[0].theoretical_hours, 0)
+        self.assertEqual(self.attendances[0].leave_hours, 0)
         self.leave_type.include_in_theoretical = True
         self.env["recompute.theoretical.attendance"].create(
             {
@@ -374,6 +382,7 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
             }
         ).action_recompute()
         self.assertEqual(self.attendances[0].theoretical_hours, 8)
+        self.assertEqual(self.attendances[0].leave_hours, 8)
 
 
 class TestHrAttendanceReportTheoreticalTimeResource(BaseCommon):

--- a/hr_attendance_report_theoretical_time/views/hr_leave_type_views.xml
+++ b/hr_attendance_report_theoretical_time/views/hr_leave_type_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <field name="request_unit" position="after">
                 <field name="include_in_theoretical" />
+                <field name="include_in_leave_theoretical" />
             </field>
         </field>
     </record>

--- a/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance.py
+++ b/hr_attendance_report_theoretical_time/wizards/recompute_theoretical_attendance.py
@@ -25,6 +25,7 @@ class RecomputeTheoreticalAttendance(models.TransientModel):
         """This method allows other modules to extend it to perform other actions
         and/or execute other methods compute from the corresponding attendances."""
         attendances._compute_theoretical_hours()
+        attendances._compute_leave_hours()
 
     def action_recompute(self):
         self.ensure_one()


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/hr-attendance/pull/290

Add leave hours column to report 

The Leave column is added to the report so that leave data can also be viewed for informational purposes

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT62028