### PR TITLE
[18.0][FIX] hr_attendance_employee_calendar_planning: Fix check_in/check_out dates

### DIFF
--- a/hr_attendance_employee_calendar_planning/models/hr_attendance.py
+++ b/hr_attendance_employee_calendar_planning/models/hr_attendance.py
@@ -30,8 +30,8 @@ class HrAattendance(models.Model):
         for employee, attendance_dates in employee_attendance_dates.items():
             data_item = defaultdict(set)
             data_item[employee] = attendance_dates
-            start_date = min(check_in for check_in, _check_out in attendance_dates)
-            end_date = max(check_out for _check_in, check_out in attendance_dates)
+            start_date = min(day for _datetime_date, day in attendance_dates)
+            end_date = max(day for _datetime_date, day in attendance_dates)
             items = self.filtered(
                 lambda x, employee=employee: x.exists() and x.employee_id == employee
             )

--- a/hr_attendance_employee_calendar_planning/models/hr_attendance.py
+++ b/hr_attendance_employee_calendar_planning/models/hr_attendance.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Tecnativa - Víctor Martínez
 from collections import defaultdict
 
-from odoo import models
+from odoo import fields, models
 
 
 class HrAattendance(models.Model):
@@ -10,9 +10,11 @@ class HrAattendance(models.Model):
     def _get_worked_hours_in_range(self, start_dt, end_dt):
         # It is important to define the appropriate context keys so that the value is
         # as expected.
+        from_date = fields.Datetime.context_timestamp(self, start_dt).date()
+        to_date = fields.Datetime.context_timestamp(self, end_dt).date()
         self = self.with_context(
-            flexible_hours_from_date=start_dt.date(),
-            flexible_hours_to_date=end_dt.date(),
+            flexible_hours_from_date=from_date,
+            flexible_hours_to_date=to_date,
         )
         # TODO: Try to remove the call to that compute in hr_employee_calendar_planning
         self.employee_id._compute_is_flexible()


### PR DESCRIPTION
Fix check_in/check_out dates

```
File "/opt/odoo/auto/addons/hr_employee_calendar_planning/models/hr_employee.py", line 57, in <lambda>
    lambda x: (not x.date_start or (from_date and x.date_start <= from_date))
TypeError: can't compare datetime.datetime to datetime.date
```
Use case example:
- Set a flexible calendar for an employee (e.g., Admin)
- Click the button in the upper-right corner to check in

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT64335