### PR TITLE
[18.0][IMP] hr_attendance_employee_calendar_planning: Remove unnecesary _get_worked_hours_in_range() method

### DIFF
--- a/hr_attendance_employee_calendar_planning/models/hr_attendance.py
+++ b/hr_attendance_employee_calendar_planning/models/hr_attendance.py
@@ -7,17 +7,6 @@ from odoo import models
 class HrAattendance(models.Model):
     _inherit = "hr.attendance"
 
-    def _get_worked_hours_in_range(self, start_dt, end_dt):
-        # It is important to define the appropriate context keys so that the value is
-        # as expected.
-        self = self.with_context(
-            flexible_hours_from_date=start_dt.date(),
-            flexible_hours_to_date=end_dt.date(),
-        )
-        # TODO: Try to remove the call to that compute in hr_employee_calendar_planning
-        self.employee_id._compute_is_flexible()
-        return super()._get_worked_hours_in_range(start_dt, end_dt)
-
     def _update_overtime(self, employee_attendance_dates=None):
         """We need to accurately determine whether the schedule is flexible or not;
         therefore, we must add specific context keys and iterate through each record

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo-addon-hr_employee_calendar_planning @ git+https://github.com/OCA/hr.git@refs/pull/1615/head#subdirectory=hr_employee_calendar_planning


### PR DESCRIPTION
Remove unnecesary _get_worked_hours_in_range() method

Related to https://github.com/OCA/hr/pull/1615

When you add the depends_context to hr_employee_calendar_planning in the employee's `is_flexbible` field,
you don't need to do anything in the `_get_worked_hours_in_range()` method for the worked_hours value
to be correct.

@Tecnativa