### PR TITLE
[19.0][FIX] hr_attendance_report_theoretical_time: Set the appropriate value for the dates in the _theoretical_hours() method

### DIFF
--- a/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
+++ b/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py
@@ -107,11 +107,16 @@ CREATE or REPLACE VIEW %s as (
         if not employee.resource_id.calendar_id:
             return 0
         tz = employee.resource_id.calendar_id.tz
+        tz_obj = pytz.timezone(tz)
         res = employee.with_context(
             exclude_public_holidays=True, employee_id=employee.id
         )._get_work_days_data_batch(
-            datetime.combine(date, time(0, 0, 0, 0, tzinfo=pytz.timezone(tz))),
-            datetime.combine(date, time(23, 59, 59, 99999, tzinfo=pytz.timezone(tz))),
+            tz_obj.localize(datetime.combine(date, time.min))
+            .astimezone(pytz.UTC)
+            .replace(tzinfo=None),
+            tz_obj.localize(datetime.combine(date, time.max))
+            .astimezone(pytz.UTC)
+            .replace(tzinfo=None),
             # Pass this domain for excluding leaves whose type is included in
             # theoretical hours
             domain=[


### PR DESCRIPTION
Related to https://github.com/OCA/hr/pull/1603

Set the appropriate value for the dates in the `_theoretical_hours()` method

If hr_employee_calendar_planning is installed and you run the tests for hr_attendance_report_theoretical_time, the following error will be displayed

```
File "/opt/odoo/auto/addons/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py", line 112, in _theoretical_hours
    )._get_work_days_data_batch(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/odoo/auto/addons/hr_employee_calendar_planning/models/hr_employee.py", line 154, in _get_work_days_data_batch
    from_dt_tz = fields.Datetime.context_timestamp(self, from_datetime)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/odoo/custom/src/odoo/odoo/orm/fields_temporal.py", line 227, in context_timestamp
    utc_timestamp = pytz.utc.localize(timestamp, is_dst=False)  # UTC = no DST
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/pytz/__init__.py", line 255, in localize
    raise ValueError('Not naive datetime (tzinfo is already set)')
ValueError: Not naive datetime (tzinfo is already set)
```

To prevent this, the specified data must not have a `tzinfo` defined.

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT64060