### PR TITLE
[19.0][IMP] hr_attendance_report_theoretical_time: hr_holidays_public compatibility

### DIFF
--- a/hr_attendance_report_theoretical_time/models/hr_employee.py
+++ b/hr_attendance_report_theoretical_time/models/hr_employee.py
@@ -103,7 +103,13 @@ class HrEmployee(models.Model):
             }
         )
         dates_to_create = {}
-        expected_attendances = self.resource_calendar_id._work_intervals_batch(
+        calendar = self.resource_calendar_id.with_context(
+            # It is important to define these context values so that
+            # `hr_holidays_public` excludes the corresponding public holidays
+            exclude_public_holidays=True,
+            employee_id=self.id,
+        )
+        expected_attendances = calendar._work_intervals_batch(
             from_datetime,
             to_datetime,
             resources=self.resource_id,

--- a/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
+++ b/hr_attendance_report_theoretical_time/tests/test_hr_attendance_report_theoretical_time.py
@@ -254,17 +254,33 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
     @mute_logger("odoo.models.unlink")
     @freeze_time("1947-01-02")
     def test_hr_attendance_cron_theoretical_hours_start_date(self):
+        attendance_model = self.env["hr.attendance"].with_context(active_test=False)
+        # Remove 1946-12-25 attendances: public holiday
+        attendance_model.search(
+            [
+                ("employee_id", "=", self.employee_1.id),
+                ("check_in", ">=", "1946-12-25"),
+                ("check_in", "<=", "1946-12-25"),
+            ]
+        ).unlink()
         self.env["hr.attendance"].action_create_empty_attendance(
             limit_date_from=datetime.date(1946, 12, 23),
             limit_date_to=datetime.date(1947, 1, 1),
         ).flush_recordset()
+        total_items_25 = attendance_model.search_count(
+            [
+                ("employee_id", "=", self.employee_1.id),
+                ("check_in", ">=", "1946-12-25"),
+                ("check_in", "<=", "1946-12-25"),
+            ]
+        )
+        self.assertEqual(total_items_25, 0)
         domain = [
             ("employee_id", "=", self.employee_1.id),
             ("active", "=", False),
             ("check_in", ">=", "1946-12-23"),
             ("check_in", "<=", "1947-01-01"),
         ]
-        attendance_model = self.env["hr.attendance"].with_context(active_test=False)
         total_items = attendance_model.search_count(domain)
         self.assertEqual(total_items, 4)
         self.employee_1.write({"theoretical_hours_start_date": "1946-12-28"})
@@ -297,17 +313,15 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
         ]
         attendance_model = self.env["hr.attendance"].with_context(active_test=False)
         total_items = attendance_model.search_count(domain)
-        self.assertEqual(total_items, 3)
+        self.assertEqual(total_items, 2)
         # Change departure_date to "1946-12-28"
         self.employee_1.write({"departure_date": "1946-12-28"})
-        attendance_model = self.env["hr.attendance"].with_context(active_test=False)
         total_items = attendance_model.search_count(domain)
-        self.assertEqual(total_items, 5)
+        self.assertEqual(total_items, 4)
         # Change departure_date again to "1946-12-25"
         self.employee_1.write({"departure_date": "1946-12-25"})
-        attendance_model = self.env["hr.attendance"].with_context(active_test=False)
         total_items = attendance_model.search_count(domain)
-        self.assertEqual(total_items, 3)
+        self.assertEqual(total_items, 2)
 
     @mute_logger("odoo.models.unlink")
     @freeze_time("1947-01-01")
@@ -341,7 +355,7 @@ class TestHrAttendanceReportTheoreticalTime(TestHrAttendanceReportTheoreticalTim
             limit_date_to=datetime.date(1946, 12, 26),
         ).flush_recordset()
         total_items = attendance_model.search_count(domain)
-        self.assertEqual(total_items, 3)
+        self.assertEqual(total_items, 2)
 
     def test_change_hr_holidays_public(self):
         self.public_holiday_global.line_ids[0].write({"date": "1946-12-23"})


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/hr-attendance/pull/310

`hr_holidays_public` compatibility

The hr_attendance_report_theoretical_time module depends on hr_holidays_public; the correct context is currently taken into account at https://github.com/OCA/hr-attendance/blob/a0cc683e4b17639c8dd4c32c5cb2f4bfb9cbad0e/hr_attendance_report_theoretical_time/reports/hr_attendance_theoretical_time_report.py#L117 so that the value of the `theoretical_hours` column is correct (0); since the automatic creation of archived attendance records on employees’ workdays was added at https://github.com/OCA/hr-attendance/pull/247, it is not at all necessary to create archived attendance records if the day in question is a public holiday; therefore, the appropriate context is added in the specific location to prevent the record from being created unnecessarily.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

https://github.com/Tecnativa