### PR TITLE
[18.0][FIX] hr_attendance_rest_time_included: reload report/hr_attendance_report_views.xml

### DIFF
--- a/hr_attendance_rest_time_included/__manifest__.py
+++ b/hr_attendance_rest_time_included/__manifest__.py
@@ -14,6 +14,7 @@
         "views/hr_attendance_views.xml",
         "views/hr_attendance_rest_time_views.xml",
         "views/hr_attendance_reason_views.xml",
+        "report/hr_attendance_report_views.xml",
     ],
     "installable": True,
     "application": False,

--- a/hr_attendance_rest_time_included/readme/CONTRIBUTORS.md
+++ b/hr_attendance_rest_time_included/readme/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Pedro M. Baeza
   - Eduardo Ezerouali
+  - Carlos Dauden

--- a/hr_attendance_rest_time_included/views/hr_attendance_views.xml
+++ b/hr_attendance_rest_time_included/views/hr_attendance_views.xml
@@ -42,16 +42,6 @@
             </field>
         </field>
     </record>
-    <record id="hr_attendance_view_pivot" model="ir.ui.view">
-        <field name="name">hr.attendance.pivot.imherit</field>
-        <field name="model">hr.attendance</field>
-        <field name="inherit_id" ref="hr_attendance.hr_attendance_view_pivot" />
-        <field name="arch" type="xml">
-            <field name="worked_hours" position="after">
-                <field name="rest_hours" widget="float_time" />
-            </field>
-        </field>
-    </record>
     <record id="hr_attendance_view_graph" model="ir.ui.view">
         <field name="name">hr.attendance.graph.inherit</field>
         <field name="model">hr.attendance</field>


### PR DESCRIPTION
… dropped from manifest

The migration to 18.0 (dd34fcf) correctly rewrote report/hr_attendance_report_views.xml (adapting it to the native hr.attendance pivot after core removed the hr.attendance.report model), but the same commit mistakenly dropped its entry from the manifest's `data` list, leaving the file orphaned and never loaded.

The same migration commit had also mistakenly added a second `hr_attendance_view_pivot` record in views/hr_attendance_views.xml, an exact duplicate of the one already defined in report/hr_attendance_report_views.xml (same inherit_id, same rest_hours field addition). Reloading report/ exposes that duplicate (xml-duplicate-record-id), so it's removed, leaving a single place where that view is defined.

@Tecnativa

ping @eduezerouali-tecnativa @sergio-teruel @carlos-lopez-tecnativa 