### PR TITLE
Add on-prem deployment config (docker-compose, nginx, Jenkins CI/CD)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ docs/_build/
 
 # OCA rules
 !static/lib/
+
+# on-prem deployment (added by odoo-deploy tooling)
+deployment/addons/
+deployment/.env

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and fill in real values before running deploy.sh
+# .env itself must NOT be committed to git.
+
+ODOO_VERSION=17.0
+
+POSTGRES_USER=odoo
+POSTGRES_PASSWORD=change-me-strong-password
+
+# Odoo master password — protects /web/database/manager (create/drop/backup DB)
+ODOO_ADMIN_PASSWORD=change-me-strong-password
+
+# Port nginx listens on for all 4 endpoints
+HTTP_PORT=80

--- a/deployment/Jenkinsfile
+++ b/deployment/Jenkinsfile
@@ -1,0 +1,66 @@
+pipeline {
+    agent any
+
+    // Trigger manually, on a schedule, or via webhook from any of the 4 addon repos.
+    // triggers { cron('H 2 * * *') }
+
+    environment {
+        DEPLOY_DIR = '/opt/odoo-deploy'   // path on the on-prem VM
+        DEPLOY_HOST = credentials('odoo-vm-ssh-host')   // e.g. deploy@10.0.0.5, Jenkins credential
+        SSH_CRED_ID = 'odoo-vm-ssh-key'
+    }
+
+    stages {
+        stage('Checkout odoo-hr-attendance (contains deployment/)') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Sync repo (module code + deployment/) to VM') {
+            steps {
+                sshagent(credentials: [env.SSH_CRED_ID]) {
+                    sh """
+                        ssh -o StrictHostKeyChecking=no ${DEPLOY_HOST} 'mkdir -p ${DEPLOY_DIR}'
+                        rsync -avz --delete \
+                          --exclude '.git' \
+                          --exclude 'deployment/addons' \
+                          --exclude 'deployment/.env' \
+                          ./ ${DEPLOY_HOST}:${DEPLOY_DIR}/
+                    """
+                }
+            }
+        }
+
+        stage('Deploy (clone other 3 addon repos + docker compose up)') {
+            steps {
+                sshagent(credentials: [env.SSH_CRED_ID]) {
+                    sh """
+                        ssh -o StrictHostKeyChecking=no ${DEPLOY_HOST} '\
+                          cd ${DEPLOY_DIR}/deployment && chmod +x clone.sh deploy.sh && ./deploy.sh'
+                    """
+                }
+            }
+        }
+
+        stage('Health check') {
+            steps {
+                sshagent(credentials: [env.SSH_CRED_ID]) {
+                    sh """
+                        ssh -o StrictHostKeyChecking=no ${DEPLOY_HOST} '\
+                          docker compose -f ${DEPLOY_DIR}/deployment/docker-compose.yml ps'
+                    """
+                }
+            }
+        }
+    }
+
+    post {
+        failure {
+            echo 'Deployment failed — check stage logs above.'
+        }
+        success {
+            echo 'Deployed. Endpoints: /HRattendance/ /timesheet/ /purchaseworkflow/ /HRexpense/'
+        }
+    }
+}

--- a/deployment/clone.sh
+++ b/deployment/clone.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Clone/update the OTHER 3 addon repos to latest main.
+# odoo-hr-attendance itself is not cloned here — this script lives inside
+# that repo already, so its own checkout (repo root, one level up) is used
+# directly as the addons source for that service.
+set -euo pipefail
+
+ORG="SystangoTechnologies"
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/addons"
+
+REPOS=(
+  "odoo-timesheet"
+  "odoo-purchase-workflow"
+  "odoo-hr-expense"
+)
+
+mkdir -p "$BASE_DIR"
+
+for repo in "${REPOS[@]}"; do
+  target="$BASE_DIR/$repo"
+  url="https://github.com/${ORG}/${repo}.git"
+  if [ -d "$target/.git" ]; then
+    echo "Updating $repo..."
+    git -C "$target" fetch origin main
+    git -C "$target" checkout main
+    git -C "$target" reset --hard origin/main
+  else
+    echo "Cloning $repo..."
+    git clone --branch main --single-branch "$url" "$target"
+  fi
+done
+
+echo "All addon repos cloned/updated under $BASE_DIR"
+echo "odoo-hr-attendance is served from the repo checkout itself (../)"

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# One-shot deploy: assumes Jenkins/CI has already synced this repo's latest
+# main (module code + deployment/) onto this VM. This script clones/updates
+# the other 3 addon repos, then (re)starts the stack.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$DIR/clone.sh"
+
+cd "$DIR"
+docker compose pull db nginx
+docker compose up -d --build
+
+echo "Deployed. Endpoints:"
+echo "  http://<host>/HRattendance/"
+echo "  http://<host>/timesheet/"
+echo "  http://<host>/purchaseworkflow/"
+echo "  http://<host>/HRexpense/"

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,0 +1,120 @@
+version: "3.8"
+
+# One Odoo instance per addon repo (Odoo has no native path-prefix routing),
+# fronted by nginx which maps /HRattendance, /timesheet, /purchaseworkflow,
+# /HRexpense to each instance. Shared Postgres server, separate DB per service.
+# Secrets/config come from .env (see .env.example) — never hardcode here.
+#
+# This compose file lives inside the odoo-hr-attendance repo itself, under
+# deployment/. The hr-attendance service mounts the repo root (../) directly
+# as its addons source; the other 3 services are cloned into ./addons by
+# clone.sh.
+
+x-odoo-common: &odoo-common
+  image: odoo:${ODOO_VERSION:-17.0}
+  restart: unless-stopped
+  depends_on:
+    - db
+  environment:
+    HOST: db
+    USER: ${POSTGRES_USER}
+    PASSWORD: ${POSTGRES_PASSWORD}
+
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  odoo-hr-attendance:
+    <<: *odoo-common
+    environment:
+      HOST: db
+      USER: ${POSTGRES_USER}
+      PASSWORD: ${POSTGRES_PASSWORD}
+      DB_NAME: hr_attendance
+      ADMIN_PASSWORD: ${ODOO_ADMIN_PASSWORD}
+      LIST_DB: "False"
+    volumes:
+      - ../:/mnt/extra-addons
+      - odoo_attendance_data:/var/lib/odoo
+    command: >
+      odoo -d hr_attendance --db_host=db --db_user=${POSTGRES_USER} --db_password=${POSTGRES_PASSWORD}
+      --addons-path=/mnt/extra-addons,/usr/lib/python3/dist-packages/odoo/addons
+      --proxy-mode
+
+  odoo-timesheet:
+    <<: *odoo-common
+    environment:
+      HOST: db
+      USER: ${POSTGRES_USER}
+      PASSWORD: ${POSTGRES_PASSWORD}
+      DB_NAME: timesheet
+      ADMIN_PASSWORD: ${ODOO_ADMIN_PASSWORD}
+      LIST_DB: "False"
+    volumes:
+      - ./addons/odoo-timesheet:/mnt/extra-addons
+      - odoo_timesheet_data:/var/lib/odoo
+    command: >
+      odoo -d timesheet --db_host=db --db_user=${POSTGRES_USER} --db_password=${POSTGRES_PASSWORD}
+      --addons-path=/mnt/extra-addons,/usr/lib/python3/dist-packages/odoo/addons
+      --proxy-mode
+
+  odoo-purchase-workflow:
+    <<: *odoo-common
+    environment:
+      HOST: db
+      USER: ${POSTGRES_USER}
+      PASSWORD: ${POSTGRES_PASSWORD}
+      DB_NAME: purchase_workflow
+      ADMIN_PASSWORD: ${ODOO_ADMIN_PASSWORD}
+      LIST_DB: "False"
+    volumes:
+      - ./addons/odoo-purchase-workflow:/mnt/extra-addons
+      - odoo_purchase_data:/var/lib/odoo
+    command: >
+      odoo -d purchase_workflow --db_host=db --db_user=${POSTGRES_USER} --db_password=${POSTGRES_PASSWORD}
+      --addons-path=/mnt/extra-addons,/usr/lib/python3/dist-packages/odoo/addons
+      --proxy-mode
+
+  odoo-hr-expense:
+    <<: *odoo-common
+    environment:
+      HOST: db
+      USER: ${POSTGRES_USER}
+      PASSWORD: ${POSTGRES_PASSWORD}
+      DB_NAME: hr_expense
+      ADMIN_PASSWORD: ${ODOO_ADMIN_PASSWORD}
+      LIST_DB: "False"
+    volumes:
+      - ./addons/odoo-hr-expense:/mnt/extra-addons
+      - odoo_expense_data:/var/lib/odoo
+    command: >
+      odoo -d hr_expense --db_host=db --db_user=${POSTGRES_USER} --db_password=${POSTGRES_PASSWORD}
+      --addons-path=/mnt/extra-addons,/usr/lib/python3/dist-packages/odoo/addons
+      --proxy-mode
+
+  nginx:
+    image: nginx:stable-alpine
+    restart: unless-stopped
+    ports:
+      - "${HTTP_PORT:-80}:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - odoo-hr-attendance
+      - odoo-timesheet
+      - odoo-purchase-workflow
+      - odoo-hr-expense
+
+volumes:
+  db_data:
+  odoo_attendance_data:
+  odoo_timesheet_data:
+  odoo_purchase_data:
+  odoo_expense_data:

--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -1,0 +1,65 @@
+server {
+    listen 80;
+    server_name _;
+
+    # HR Attendance
+    location /HRattendance/ {
+        proxy_pass http://odoo-hr-attendance:8069/;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Script-Name /HRattendance;
+    }
+    location = /HRattendance {
+        return 301 /HRattendance/;
+    }
+
+    # Timesheet
+    location /timesheet/ {
+        proxy_pass http://odoo-timesheet:8069/;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Script-Name /timesheet;
+    }
+    location = /timesheet {
+        return 301 /timesheet/;
+    }
+
+    # Purchase Workflow
+    location /purchaseworkflow/ {
+        proxy_pass http://odoo-purchase-workflow:8069/;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Script-Name /purchaseworkflow;
+    }
+    location = /purchaseworkflow {
+        return 301 /purchaseworkflow/;
+    }
+
+    # HR Expense
+    location /HRexpense/ {
+        proxy_pass http://odoo-hr-expense:8069/;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Script-Name /HRexpense;
+    }
+    location = /HRexpense {
+        return 301 /HRexpense/;
+    }
+
+    location / {
+        return 200 "Odoo services: /HRattendance/ /timesheet/ /purchaseworkflow/ /HRexpense/\n";
+        add_header Content-Type text/plain;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `deployment/` with `docker-compose.yml` running this repo's addons plus the 3 sibling repos (`odoo-timesheet`, `odoo-purchase-workflow`, `odoo-hr-expense`) as separate Odoo instances against a shared Postgres.
- nginx path-based routing: `/HRattendance`, `/timesheet`, `/purchaseworkflow`, `/HRexpense`.
- `clone.sh` pulls latest `main` of the 3 sibling repos at deploy time; this repo's own checkout (synced by Jenkins) is mounted directly as its addons path.
- `Jenkinsfile` rsyncs the repo to the on-prem VM and runs the deploy.
- `.env.example` documents required secrets (Postgres creds, Odoo admin password); real `.env` stays on the VM only, not committed.

## Test plan
- [ ] `cp deployment/.env.example deployment/.env` on VM, fill real values
- [ ] `cd deployment && ./clone.sh && docker compose up -d`
- [ ] Confirm all 4 endpoints load and prompt Odoo DB init on first run
- [ ] Wire Jenkins credentials (`odoo-vm-ssh-host`, `odoo-vm-ssh-key`) and run pipeline end-to-end